### PR TITLE
Stops unused warnings for generated parameters

### DIFF
--- a/examples/boomerang.tzw
+++ b/examples/boomerang.tzw
@@ -48,7 +48,7 @@ end
 
 scope Unknown
 
-  predicate pre (c : ctx) = true
+  predicate pre (_c : ctx) = true
 
   predicate post (c : ctx) (c' : ctx) =
     c.boomerang_balance = c'.boomerang_balance
@@ -65,15 +65,15 @@ scope Boomerang
 
   type storage = unit
 
-  predicate pre (c : ctx) = true
+  predicate pre (_c : ctx) = true
 
-  predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) = inv_post c c'
+  predicate post (_st : step) (_gp : gparam) (c : ctx) (c' : ctx) = inv_post c c'
 
   let upper_ops = 1
 
   scope Spec
 
-  predicate default (st : step) (p : unit) (s : storage) (ops : list operation) (s' : storage) =
+  predicate default (st : step) (_p : unit) (_s : storage) (ops : list operation) (_s' : storage) =
     (st.amount = 0 -> ops = Nil) /\
     (st.amount > 0 -> ops = Cons (Xfer (Gp'Unknown'default ()) st.amount st.sender) Nil)
 

--- a/examples/boomerang_acc.tzw
+++ b/examples/boomerang_acc.tzw
@@ -48,7 +48,7 @@ end
 
 scope Unknown
 
-  predicate pre (c : ctx) = true
+  predicate pre (_c : ctx) = true
 
   predicate post (c : ctx) (c' : ctx) =
     c.boomerang_storage <= c'.boomerang_storage /\
@@ -66,15 +66,15 @@ scope Boomerang
 
   type storage = mutez
 
-  predicate pre (c : ctx) = true
+  predicate pre (_c : ctx) = true
 
-  predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) = inv_post c c'
+  predicate post (_st : step) (_gp : gparam) (c : ctx) (c' : ctx) = inv_post c c'
 
   let upper_ops = 1
 
   scope Spec
 
-  predicate default (st : step) (p : unit) (s : storage) (ops : list operation) (s' : storage) =
+  predicate default (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
     s' = s + st.amount /\
     (st.amount = 0 -> ops = Nil) /\
     (st.amount > 0 -> ops = Cons (Xfer (Gp'Unknown'default ()) st.amount st.sender) Nil)

--- a/examples/dexter2/liquidity.tzw
+++ b/examples/dexter2/liquidity.tzw
@@ -137,13 +137,13 @@ scope Cpmm
 
   predicate pre (c : ctx) = pre_inv c
 
-  predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) = post_inv c c'
+  predicate post (_st : step) (_gp : gparam) (c : ctx) (c' : ctx) = post_inv c c'
 
   let upper_ops = 3
 
   scope Spec
 
-  predicate add_liquidity (st : step) (p1 : address) (p2 : nat) (p3 : nat) (p4 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate add_liquidity (_st : step) (_p1 : address) (_p2 : nat) (_p3 : nat) (_p4 : timestamp) (s : storage) (op : list operation) (s' : storage) =
     s.lqt_address <> null_addr /\
     s'.lqt_address = s.lqt_address /\
     let lqt_minted = s'.lqt_total - s.lqt_total in
@@ -155,7 +155,7 @@ scope Cpmm
     | _ -> False
     end
 
-  predicate remove_liquidity (st : step) (p1 : address) (p2 : nat) (p3 : mutez) (p4 : nat) (p5 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate remove_liquidity (_st : step) (_p1 : address) (p2 : nat) (_p3 : mutez) (_p4 : nat) (_p5 : timestamp) (s : storage) (op : list operation) (s' : storage) =
     let lqt_burned = p2 in
     s.lqt_address <> null_addr /\
     s'.lqt_address = s.lqt_address /\
@@ -169,7 +169,7 @@ scope Cpmm
     | _ -> False
     end
 
-  predicate xtz_to_token (st : step) (p1 : address) (p2 : nat) (p3 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate xtz_to_token (_st : step) (_p1 : address) (_p2 : nat) (_p3 : timestamp) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
@@ -178,7 +178,7 @@ scope Cpmm
     | _ -> False
     end
 
-  predicate token_to_xtz (st : step) (p1 : address) (p2 : nat) (p3 : mutez) (p4 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate token_to_xtz (_st : step) (_p1 : address) (_p2 : nat) (_p3 : mutez) (_p4 : timestamp) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
@@ -188,7 +188,7 @@ scope Cpmm
     | _ -> False
     end
 
-  predicate token_to_token (st : step) (p1 : address) (p2 : nat) (p3 : address) (p4 : nat) (p5 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate token_to_token (_st : step) (_p1 : address) (_p2 : nat) (_p3 : address) (_p4 : nat) (_p5 : timestamp) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
@@ -198,7 +198,7 @@ scope Cpmm
     | _ -> False
     end
 
-  predicate set_baker (st : step) (p1 : option key_hash) (p2 : bool) (s : storage) (op : list operation) (s' : storage) =
+  predicate set_baker (_st : step) (_p1 : option key_hash) (_p2 : bool) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
@@ -207,18 +207,18 @@ scope Cpmm
     | _ -> False
     end
 
-  predicate set_manager (st : step) (p : address) (s : storage) (op : list operation) (s' : storage) =
+  predicate set_manager (_st : step) (_p : address) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     op = Nil
 
-  predicate set_lqt_address (st : step) (p : address) (s : storage) (op : list operation) (s' : storage) =
+  predicate set_lqt_address (_st : step) (p : address) (s : storage) (op : list operation) (s' : storage) =
     s.lqt_address = null_addr /\
     s'.lqt_address = p /\
     s'.lqt_total = s.lqt_total /\
     op = Nil
 
-  predicate update_token_pool (st : step) (p : unit) (s : storage) (op : list operation) (s' : storage) =
+  predicate update_token_pool (_st : step) (_p : unit) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
@@ -227,12 +227,12 @@ scope Cpmm
     | _ -> False
     end
 
-  predicate update_token_pool_internal (st : step) (p : list ((address, nat), nat)) (s : storage) (op : list operation) (s' : storage) =
+  predicate update_token_pool_internal (_st : step) (_p : list ((address, nat), nat)) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     op = Nil
 
-  predicate default (st : step) (p : unit) (s : storage) (op : list operation) (s' : storage) =
+  predicate default (_st : step) (_p : unit) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     op = Nil
@@ -259,7 +259,7 @@ scope Lqt
 
   scope Spec
 
-  predicate transfer (st : step) (p1 : address) (p2 : address) (p3 : nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate transfer (_st : step) (p1 : address) (p2 : address) (p3 : nat) (s : storage) (op : list operation) (s' : storage) =
     let address_from = p1 in
     let address_to = p2 in
     let value = p3 in
@@ -277,7 +277,7 @@ scope Lqt
     s'.tokens = tokens[address_to <- maybe_to_balance] /\
     op = Nil
 
-  predicate approve (st : step) (p1 : address) (p2 : nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate approve (_st : step) (_p1 : address) (_p2 : nat) (s : storage) (op : list operation) (s' : storage) =
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
@@ -294,7 +294,7 @@ scope Lqt
     let maybe_new_balance = if new_balance = 0 then None else Some new_balance in
     s'.tokens = s.tokens[target <- maybe_new_balance]
 
-  predicate getAllowance (st : step) (p1 : (address, address)) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate getAllowance (_st : step) (_p1 : (address, address)) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
@@ -305,7 +305,7 @@ scope Lqt
     | _ -> False
     end
 
-  predicate getBalance (st : step) (p1 : address) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate getBalance (_st : step) (_p1 : address) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
@@ -316,7 +316,7 @@ scope Lqt
     | _ -> False
     end
 
-  predicate getTotalSupply (st : step) (p1 : unit) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate getTotalSupply (_st : step) (_p1 : unit) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\

--- a/lib/gen_mlw.ml
+++ b/lib/gen_mlw.ml
@@ -169,13 +169,13 @@ module E = struct
     let p =
       pat
       @@ Ptuple
-           (List.init m (fun i -> pat @@ Pvar (ident @@ Format.sprintf "x%d" i)))
+           (List.init m (fun i -> pat @@ Pvar (ident @@ Format.sprintf "_x%d" i)))
     in
     let e =
       expr
       @@ Etuple
            (List.init m (fun i ->
-                if i = n then e2 else mk_var (ident @@ Format.sprintf "x%d" i)))
+                if i = n then e2 else mk_var (ident @@ Format.sprintf "_x%d" i)))
     in
     expr @@ Ematch (e1, [ (p, e) ], [])
 
@@ -203,10 +203,10 @@ let rec sort_wf (s : Sort.t) (p : expr) : term =
       @@ Tcase
            ( T.of_expr p,
              [
-               ( pat @@ Papp (qualid [ "Left" ], [ pat @@ Pvar (ident "p") ]),
-                 sort_wf s1 @@ E.mk_var @@ ident "p" );
-               ( pat @@ Papp (qualid [ "Right" ], [ pat @@ Pvar (ident "p") ]),
-                 sort_wf s2 @@ E.mk_var @@ ident "p" );
+               ( pat @@ Papp (qualid [ "Left" ], [ pat @@ Pvar (ident "_p") ]),
+                 sort_wf s1 @@ E.mk_var @@ ident "_p" );
+               ( pat @@ Papp (qualid [ "Right" ], [ pat @@ Pvar (ident "_p") ]),
+                 sort_wf s2 @@ E.mk_var @@ ident "_p" );
              ] )
   | _ -> term Ttrue
 
@@ -692,14 +692,14 @@ let gen_spec (epp : Sort.t list StringMap.t) =
         let params =
           List.mapi
             (fun i _ ->
-              Ptree_helpers.(pat_var @@ ident @@ Format.sprintf "p%d" i))
+              Ptree_helpers.(pat_var @@ ident @@ Format.sprintf "_p%d" i))
             s
         in
         let args =
           args
           @ List.mapi
               (fun i _ ->
-                Ptree_helpers.(tvar @@ qualid [ Format.sprintf "p%d" i ]))
+                Ptree_helpers.(tvar @@ qualid [ Format.sprintf "_p%d" i ]))
               s
         in
         Ptree_helpers.
@@ -732,7 +732,7 @@ let gen_param_wf ep =
         let params, preds =
           List.mapi
             (fun i s ->
-              let p = ident @@ Format.sprintf "p%d" i in
+              let p = ident @@ Format.sprintf "_p%d" i in
               (Ptree_helpers.(pat_var p), sort_wf s @@ E.mk_var p))
             s
           |> List.split
@@ -757,7 +757,7 @@ let gen_param_wf ep =
 let gen_storage_wf td =
   let sto : Ptree.param =
     ( Loc.dummy_position,
-      Some (Ptree_helpers.ident "s"),
+      Some (Ptree_helpers.ident "_s"),
       false,
       PTtyapp (Ptree_helpers.qualid [ "storage" ], []) )
   in


### PR DESCRIPTION
This patch renames generated pattern variables like x1 to _x1 to suppress "unused variable" warnings as follows:

```
Output the translation to /tmp/dexter_s.mlw
File "", line 0, characters 0-0:
warning: unused variable p
File "", line 0, characters 0-0:
warning: unused variable s
File "", line 0, characters 0-0:
warning: unused variable x1
File "", line 0, characters 0-0:
warning: unused variable x3
File "", line 0, characters 0-0:
warning: unused variable p
File "", line 0, characters 0-0:
warning: unused variable p
File "", line 0, characters 0-0:
warning: unused variable s
File "", line 0, characters 0-0:
warning: unused variable x0
File "", line 0, characters 0-0:
warning: unused variable x2
```
