### PR TITLE
Adds 'module Top' to make why3 -T option work with tzw

### DIFF
--- a/lib/gen_mlw.ml
+++ b/lib/gen_mlw.ml
@@ -934,12 +934,13 @@ let convert_mlw (tzw : Tzw.t) =
     let desc = { d_contracts; d_whyml = [] }
   end) in
   return
-  @@ Decls
-       (tzw.tzw_preambles
-       @ (gen_gparam epp :: G.operation_ty_def :: ds)
-       @ [ G.ctx_ty_def; G.ctx_wf_def ]
-       @ tzw.tzw_postambles @ invariants
-       @ [ Drec (G.unknown_func_def :: G.func_def) ])
+  @@ Modules [ ident "Top",
+               tzw.tzw_preambles
+               @ (gen_gparam epp :: G.operation_ty_def :: ds)
+               @ [ G.ctx_ty_def; G.ctx_wf_def ]
+               @ tzw.tzw_postambles @ invariants
+               @ [ Drec (G.unknown_func_def :: G.func_def) ]
+             ]
 
 (* let file desc = *)
 (*   let module G = Generator (struct *)


### PR DESCRIPTION
This PR wraps the output of `gen_mlw.ml` by `module Top .. end`.

## Issue fixed by this PR

Why3 1.5.1 + Icon fails to prove a `*.tzw` file with `-G` option:

```
% why3 prove -P z3 examples/boomerang.tzw -G "boomerang_func'vc"
Theory 'Top' not found in file 'examples/boomerang.tzw'.
```

However, it works when `*.tzw` is converted to `*.mlw`:

```
% dune exec icon examples/boomerang.tzw  > /tmp/boomerang.mlw
% why3 prove -P z3 /tmp/boomerang.mlw -G "boomerang_func'vc"
...
File /tmp/boomerang.mlw:
Goal boomerang_func'vc.
Prover result is: Timeout (5.00s, 3846893104 steps).
```

Why3 seems to have an issue of the top module/theory name handling.  Explicit adding of the top module name can workaround this issue:

```
# After this PR
% why3 prove -P z3 examples/boomerang.tzw -G "boomerang_func'vc"
...
File /tmp/boomerang.mlw:
Goal boomerang_func'vc.
Prover result is: Timeout (5.00s, 3846893104 steps).
```
