### PR TITLE
Adds re to embed_in_plugin_libraries

### DIFF
--- a/plugin/dune
+++ b/plugin/dune
@@ -2,7 +2,7 @@
  (name plugin_icon)
  (modes plugin)
  (libraries why3 lib_icon)
- (embed_in_plugin_libraries lib_icon)
+ (embed_in_plugin_libraries re lib_icon)
  (flags
   (:standard -open Lib_icon)))
 


### PR DESCRIPTION
This PR fixes the current issue of dynlinking of the plugin with why3.1.6.0:

```
% why3 prove -P z3 examples/boomerang.tzw 
/Users/jun/icon/icon-why3/_opam/lib/why3/plugins/plugin_icon cannot be loaded: 
Dynlink error: error loading shared library: Dynlink error: error loading shared library: Failure("dlopen(/Users/jun/icon/icon-why3/_opam/lib/why3/plugins/plugin_icon.cmxs, 0x0006): symbol not found in flat namespace '_camlRe__Core__alt_1968'")
Unknown file extension: `tzw'
```
