### PR TITLE
Uses a record type for Michelson.step

### DIFF
--- a/examples/auction.tzw
+++ b/examples/auction.tzw
@@ -24,24 +24,20 @@ scope Preambles
 
   type or 'a 'b = Left 'a | Right 'b
 
-  type step = (address, address, address, mutez)
+  type step = 
+    { source: address;
+      sender: address;
+      self: address;
+      amount: mutez
+    }
 
   function mk_step (source : address) (sender : address) (self : address) (amount : mutez) : step =
-    (source, sender, self, amount)
+    { source= source; 
+      sender= sender;
+      self= self;
+      amount= amount }
 
-  function source (st : step) : address =
-    match st with x, _, _, _ -> x end
-
-  function sender (st : step) : address =
-    match st with _, x, _, _ -> x end
-
-  function self (st : step) : address =
-    match st with _, _, x, _ -> x end
-
-  function amount (st : step) : mutez =
-    match st with  _, _, _, x -> x end
-
-  predicate st_wf (st : step) =
+  predicate step_wf (st : step) =
     st.amount >= 0
 
   function sum_of : map address mutez -> mutez

--- a/examples/boomerang.tzw
+++ b/examples/boomerang.tzw
@@ -24,24 +24,20 @@ scope Preambles
 
   type or 'a 'b = Left 'a | Right 'b
 
-  type step = (address, address, address, mutez)
+  type step = 
+    { source: address;
+      sender: address;
+      self: address;
+      amount: mutez
+    }
 
   function mk_step (source : address) (sender : address) (self : address) (amount : mutez) : step =
-    (source, sender, self, amount)
+    { source= source; 
+      sender= sender;
+      self= self;
+      amount= amount }
 
-  function source (st : step) : address =
-    match st with x, _, _, _ -> x end
-
-  function sender (st : step) : address =
-    match st with _, x, _, _ -> x end
-
-  function self (st : step) : address =
-    match st with _, _, x, _ -> x end
-
-  function amount (st : step) : mutez =
-    match st with  _, _, _, x -> x end
-
-  predicate st_wf (st : step) =
+  predicate step_wf (st : step) =
     st.amount >= 0
 
 end

--- a/examples/boomerang_acc.tzw
+++ b/examples/boomerang_acc.tzw
@@ -24,24 +24,20 @@ scope Preambles
 
   type or 'a 'b = Left 'a | Right 'b
 
-  type step = (address, address, address, mutez)
+  type step = 
+    { source: address;
+      sender: address;
+      self: address;
+      amount: mutez
+    }
 
   function mk_step (source : address) (sender : address) (self : address) (amount : mutez) : step =
-    (source, sender, self, amount)
+    { source= source; 
+      sender= sender;
+      self= self;
+      amount= amount }
 
-  function source (st : step) : address =
-    match st with x, _, _, _ -> x end
-
-  function sender (st : step) : address =
-    match st with _, x, _, _ -> x end
-
-  function self (st : step) : address =
-    match st with _, _, x, _ -> x end
-
-  function amount (st : step) : mutez =
-    match st with  _, _, _, x -> x end
-
-  predicate st_wf (st : step) =
+  predicate step_wf (st : step) =
     st.amount >= 0
 
 end

--- a/examples/dexter2/liquidity.tzw
+++ b/examples/dexter2/liquidity.tzw
@@ -24,24 +24,20 @@ scope Preambles
 
   type or 'a 'b = Left 'a | Right 'b
 
-  type step = (address, address, address, mutez)
+  type step = 
+    { source: address;
+      sender: address;
+      self: address;
+      amount: mutez
+    }
 
   function mk_step (source : address) (sender : address) (self : address) (amount : mutez) : step =
-    (source, sender, self, amount)
+    { source= source; 
+      sender= sender;
+      self= self;
+      amount= amount }
 
-  function source (st : step) : address =
-    match st with x, _, _, _ -> x end
-
-  function sender (st : step) : address =
-    match st with _, x, _, _ -> x end
-
-  function self (st : step) : address =
-    match st with _, _, x, _ -> x end
-
-  function amount (st : step) : mutez =
-    match st with  _, _, _, x -> x end
-
-  predicate st_wf (st : step) =
+  predicate step_wf (st : step) =
     st.amount >= 0
 
   function sum_of : map address (option nat) -> nat

--- a/stdlib/michelson.mlw
+++ b/stdlib/michelson.mlw
@@ -106,23 +106,20 @@ module Michelson
 
   type or 'a 'b = Left 'a | Right 'b
 
-  type step = (address, address, address, Mutez.t)
+  type step =
+    { source : address;
+      sender : address;
+      self : address;
+      amount : mutez
+    }
 
-  function mk_step (source : address) (sender : address) (self : address) (amount : Mutez.t) : step =
-    (source, sender, self, amount)
+  function mk_step (source : address) (sender : address) (self : address) (amount : mutez) : step =
+    { source= source;
+      sender= sender;
+      self= self;
+      amount= amount
+    }
 
-  function source (st : step) : address =
-    match st with x, _, _, _ -> x end
-
-  function sender (st : step) : address =
-    match st with _, x, _, _ -> x end
-
-  function self (st : step) : address =
-    match st with _, _, x, _ -> x end
-
-  function amount (st : step) : Mutez.t =
-    match st with _, _, _, x -> x end
-
-  predicate st_wf (st : step) = true
+  predicate step_wf (st : step) = true
 
 end

--- a/test/auction.mlw
+++ b/test/auction.mlw
@@ -111,7 +111,7 @@ let rec ghost unknown (g : int) (c : ctx) : ctx
   else
   if any bool then c
   else
-  let st = any step ensures { st_wf result } in
+  let st = any step ensures { step_wf result } in
   let dst = st.self in
   let p = any param in
   assume
@@ -135,7 +135,7 @@ let rec ghost unknown (g : int) (c : ctx) : ctx
 
 with ghost auction_func (g : int) (st : step) (p : auction_param) (c : ctx) : ctx
   requires { st.self = auction }
-  requires { st_wf st }
+  requires { step_wf st }
   requires { ctx_wf c }
   ensures { ctx_wf result }
   requires { auction_sigma_pre st c }

--- a/test/boomerang.mlw
+++ b/test/boomerang.mlw
@@ -51,7 +51,7 @@ let rec ghost unknown (g : int) (c : ctx) : ctx
   else
   if any bool then c
   else
-  let st = any step ensures { st_wf result } in
+  let st = any step ensures { step_wf result } in
   let dst = st.self in
   let p = any param in
   assume
@@ -74,7 +74,7 @@ let rec ghost unknown (g : int) (c : ctx) : ctx
 
 with ghost boomerang_func (g : int) (st : step) (p : unit) (c : ctx) : ctx
   requires { st.self = boomerang }
-  requires { st_wf st }
+  requires { step_wf st }
   requires { ctx_wf c }
   ensures { ctx_wf result }
   requires { c.ledger[st.self] >= st.amount }

--- a/test/dexter.mlw
+++ b/test/dexter.mlw
@@ -129,7 +129,7 @@ let rec ghost unknown (g : int) (c : ctx) : ctx
   else
   if any bool then c
   else
-  let st = any step ensures { st_wf result } in
+  let st = any step ensures { step_wf result } in
   let dst = st.self in
   let p = any param in
   assume


### PR DESCRIPTION
This PR changes the tuple type `step` to a record.  From:

```
type step = (address, address, address, Mutez.t)
```

to:

```
type step =
   { source : address;
     sender : address;
     self : address;
     amount : mutez
   }
```

This disambiguates the 3 `address` types of `step`.  We can also omit the accessors definitions such as `source`, `sender`, etc from `michelson.mlw` since the fields introduce them automatically.

It also renames `st_wf` by `step_wf` following the other `<typename>_wf` function names.