### PR TITLE
Fix version dependency for ocaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -8,6 +8,9 @@
  (name icon)
  (synopsis "icon-why3")
  (description "why3 plugin for icon project")
- (depends 
-   (why3 (>= "1.7.0"))
-   re))
+ (depends
+  (ocaml
+   (>= "4.14"))
+  (why3
+   (>= "1.7.0"))
+  re))

--- a/icon.opam
+++ b/icon.opam
@@ -4,6 +4,7 @@ synopsis: "icon-why3"
 description: "why3 plugin for icon project"
 depends: [
   "dune" {>= "2.9"}
+  "ocaml" {>= "4.14"}
   "why3" {>= "1.7.0"}
   "re"
   "odoc" {with-doc}


### PR DESCRIPTION
This RP adds insufficient package dependency.

The `In_channel` module in `lib/gen_mlw.ml` is introduced at OCaml 4.14, so we need version specification for OCaml.