### PR TITLE
Draft: Allow to define any type

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -27,6 +27,8 @@ type t =
   | S_key_hash
   | S_signature
   | S_chain_id
+  (* User defined data type *)
+  | S_any of string
 
 (* Other Michelson types but not implemented yet *)
 (* | S_never
@@ -72,6 +74,7 @@ let rec pp_sort fmt (ty : t) =
   | S_key_hash -> fprintf fmt "key_hash"
   | S_signature -> fprintf fmt "signature"
   | S_chain_id -> fprintf fmt "chain_id"
+  | S_any str -> fprintf fmt "%s" str
 
 let string_of_sort (ty : t) : string =
   let open Format in
@@ -147,7 +150,7 @@ let rec sort_of_pty (pty : pty) : t iresult =
       | "contract" ->
           let* s = elt1 pl in
           return @@ S_contract s
-      | s -> error_with "unknown sort %s" s)
+      | s -> return (S_any s)(* error_with "unknown sort %s" s *))
   | PTtuple [] -> return @@ S_unit
   | PTtuple [ pty ] -> sort_of_pty pty
   | PTtuple ([ _; _ ] as pl) ->
@@ -190,3 +193,4 @@ let rec pty_of_sort (s : t) : Ptree.pty =
   | S_key_hash -> ty "key_hash"
   | S_signature -> ty "signature"
   | S_chain_id -> ty "chain_id"
+  | S_any str -> ty str

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -27,6 +27,7 @@ type t =
   | S_key_hash
   | S_signature
   | S_chain_id
+  | S_any of string
 
 (* Other Michelson types but not implemented yet *)
 (* | S_never

--- a/lib/tzw.mli
+++ b/lib/tzw.mli
@@ -20,6 +20,7 @@ type entrypoint = {
 
 type contract = {
   c_name : ident;
+  c_types : type_decl list;
   c_store_ty : type_decl;
   c_entrypoints : entrypoint list;
   c_num_kont : int;


### PR DESCRIPTION
Someone wants to define a record type that is used in `storage` type
```
type point = { x : int; y : int }
type storage = { a : option point ; b : point }
```

This PR changes to allow to define types whose name is not "storage"