### PR TITLE
Allow why3 types for storages

### DIFF
--- a/examples/auction.tzw
+++ b/examples/auction.tzw
@@ -34,7 +34,7 @@ end
 
 scope Auction
 
-  type storage = {
+  type storage [@gen_wf] = {
     beneficiary : address;
     highest_bidder : address;
     highest_bid : mutez;

--- a/examples/boomerang.tzw
+++ b/examples/boomerang.tzw
@@ -15,7 +15,7 @@ end
 
 scope Boomerang
 
-  type storage = unit
+  type storage [@gen_wf] = unit
 
   predicate pre (_c : ctx) = true
 

--- a/examples/boomerang_acc.tzw
+++ b/examples/boomerang_acc.tzw
@@ -16,7 +16,7 @@ end
 
 scope Boomerang
 
-  type storage = mutez
+  type storage [@gen_wf] = mutez
 
   predicate pre (_c : ctx) = true
 

--- a/examples/dexter2/liquidity.tzw
+++ b/examples/dexter2/liquidity.tzw
@@ -78,7 +78,7 @@ end
 
 scope Cpmm
 
-  type storage = {
+  type storage [@gen_wf] = {
     token_pool : nat;
     xtz_pool : mutez;
     lqt_total : nat;
@@ -198,9 +198,11 @@ end
 
 scope Lqt
 
-  type storage = {
+  type allowance_key [@gen_wf] = { owner : address; spender : address }
+
+  type storage [@gen_wf] = {
     tokens : map address (option nat);
-    allowances : map (address, address) (option nat);
+    allowances : map allowance_key (option nat);
     admin : address;
     total_supply : nat;
     }

--- a/lib/error_monad.ml
+++ b/lib/error_monad.ml
@@ -1,15 +1,41 @@
 open Why3
 
-type error = Exn of (Loc.position option * exn)
-type 'a iresult = ('a, error list) Result.t
+type error = Loc.position option * exn
+
+type trace = error list
+
+exception Trace of trace
+
+let () =
+  Exn_printer.register (fun ppf -> function
+      | Failure s ->
+         Format.pp_print_string ppf s
+      | Trace errors ->
+         let open Format in
+         fprintf ppf "@[<v>%a@]"
+           (pp_print_list
+              ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
+              (fun ppf -> function
+                | Some loc, e ->
+                   fprintf ppf
+                     "@[<2>File %a:@ %a@]"
+                     Loc.pp_position loc
+                     Exn_printer.exn_printer e
+                | None, e ->
+                   Exn_printer.exn_printer ppf e))
+           errors
+      | e -> raise e)
+
+type 'a iresult = ('a, trace) Result.t
 
 let return = Result.ok
+
 let error (e : error) : 'a iresult = Result.error [ e ]
 
 let error_with ?loc msg =
-  Format.kasprintf (fun s -> error @@ Exn (loc, Failure s)) msg
+  Format.kasprintf (fun s -> error @@ (loc, Failure s)) msg
 
-let error_of_fmt ?loc msg = Format.kasprintf (fun s -> Exn (loc, Failure s)) msg
+let error_of_fmt ?loc msg = Format.kasprintf (fun s -> (loc, Failure s)) msg
 
 let trace ~(err : error) (m : 'a iresult) : 'a iresult =
   match m with Ok v -> return v | Error tr -> Error (err :: tr)
@@ -21,15 +47,7 @@ let ( >>= ) = Result.bind
 let ( let* ) = Result.bind
 
 let raise_error (m : 'a iresult) : 'a =
-  let rec fmt_trace ?loc tr =
-    match tr with
-    | [] -> assert false
-    | [ Exn (None, e) ] -> Loc.error ?loc e
-    | [ Exn (Some loc, e) ] -> Loc.error ~loc e
-    | Exn (None, _) :: tl -> fmt_trace ?loc tl
-    | Exn (Some loc, _) :: tl -> fmt_trace ~loc tl
-  in
-  match m with Ok v -> v | Error tr -> fmt_trace tr
+  match m with Ok v -> v | Error tr -> raise (Trace tr)
 
 module StringMap = struct
   include Map.Make (String)

--- a/lib/error_monad.mli
+++ b/lib/error_monad.mli
@@ -1,7 +1,9 @@
-type error = Exn of (Why3.Loc.position option * exn)
+type error = Why3.Loc.position option * exn
+
 type 'a iresult = ('a, error list) result
 
 val return : 'a -> ('a, 'b) result
+
 val error : error -> 'a iresult
 
 val error_with :

--- a/lib/mlw/preambles.mlw
+++ b/lib/mlw/preambles.mlw
@@ -9,21 +9,59 @@ use export map.Const
 exception Insufficient_mutez
 exception Terminate
 
+predicate is__tuple2_wf (is_a_wf : 'a -> bool) (is_b_wf : 'b -> bool) (ab : ('a, 'b)) =
+  let (a,b) = ab in
+  is_a_wf a /\ is_b_wf b
+
+predicate is_list_wf (_ : 'a -> bool) (_ : list 'a) = true
+
+predicate is_unit_wf (_ : unit) = true
+
+predicate is_bool_wf (_ : bool) = true
+
+predicate is_map_wf (_ : 'a -> bool) (_ : 'b -> bool) (_ : map 'a 'b) = true
+
+predicate is_option_wf (is_a_wf : 'a -> bool) (o : option 'a) =
+  match o with
+  | None -> true
+  | Some a -> is_a_wf a
+  end
+
+predicate is_int_wf (_ : int) = true
+
 type nat = int
+
+predicate is_nat_wf (x : nat) = x >= 0
 
 type mutez = int
 
+predicate is_mutez_wf (x : mutez) = x >= 0
+
 type address = int
+
+predicate is_address_wf (_ : address) = true
 
 type key_hash = int
 
+predicate is_key_hash_wf (_ : address) = true
+
 type timestamp = int
+
+predicate is_timestamp_wf (_ : address) = true
 
 type contract 'a = int
 
+predicate is_contract_wf (_ : 'a -> bool) (_ : contract 'a) = true
+
 type or 'a 'b = Left 'a | Right 'b
 
-type step = 
+predicate is_or_wf (is_a_wf : 'a -> bool) (is_b_wf : 'b -> bool) (ab : or 'a 'b) =
+  match ab with
+  | Left a -> is_a_wf a
+  | Right b -> is_b_wf b
+  end
+
+type step =
   { source: address;
     sender: address;
     self: address;
@@ -31,7 +69,7 @@ type step =
   }
 
 function mk_step (source : address) (sender : address) (self : address) (amount : mutez) : step =
-  { source= source; 
+  { source= source;
     sender= sender;
     self= self;
     amount= amount }

--- a/lib/tzw.mli
+++ b/lib/tzw.mli
@@ -20,11 +20,11 @@ type entrypoint = {
 
 type contract = {
   c_name : ident;
-  c_store_ty : type_decl;
   c_entrypoints : entrypoint list;
   c_num_kont : int;
   c_pre : logic_decl;
   c_post : logic_decl;
+  c_other_decls : decl list;
 }
 
 type t = {


### PR DESCRIPTION
This PR allows using any Why3 types as contract storage.

The wellformed predicate for the storage is now `is_storage_wf`, and it is generatable if the type is annotated with an attribute `[@gen_wf]`. ex:

```
type storage [@gen_wf] = 
  { x : int;
    y : int }
```

With the attribute, the predicate `is_storage_wf` is generated like in OCaml's ppx-deriving.
If the attribute is omitted, the predicate must be defined by hand in `.tzw`.

This auto-generation is applicable for other data type declarations in `.tzw`.  For example,

```
type address_pair [@gen_wf] = 
  { user : address;
    counterparty : address
  }

type storage [@gen_wf] =
  { address_pairs : list address_pair;
    y : int
  }
```

Here, there is no need to define `is_address_wf` nor `is_int_wf` since these WF predicates for the basic Michelson type constructors are defined in `preambles.mlw`.
