### PR TITLE
Apply [@gen_wf] conversions to preambles

### DIFF
--- a/lib/error_monad.ml
+++ b/lib/error_monad.ml
@@ -91,4 +91,8 @@ module List = struct
 
   let iter_e (f : 'a -> unit iresult) (l : 'a list) : unit iresult =
     fold_left_e (fun () x -> f x) () l
+
+  let concat_map_e f l =
+    let* xs = map_e f l in
+    return @@ concat xs
 end

--- a/lib/error_monad.mli
+++ b/lib/error_monad.mli
@@ -43,4 +43,5 @@ module List : sig
 
   val map_e : ('a -> 'b iresult) -> 'a list -> 'b list iresult
   val iter_e : ('a -> unit iresult) -> 'a list -> unit iresult
+  val concat_map_e : ('a -> 'b list iresult) -> 'a list -> 'b list iresult
 end


### PR DESCRIPTION
Fixes issue https://github.com/SoftwareFoundationGroupAtKyotoU/icon-why3/issues/24

`is_type_wf` predicates are also generated for the type declarations in preambles when they are with the `[@gen_wf]` attribute.
