### PR TITLE
 Add st.balance consistent with contract_balance

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -65,4 +65,5 @@ jobs:
       - run: opam exec -- why3 prove -P z3 examples/boomerang_acc.tzw
       - run: opam exec -- why3 prove -P z3 examples/auction.tzw
       - run: opam exec -- why3 prove -P z3 examples/callback.tzw
+      - run: opam exec -- why3 prove -P z3 examples/test_balance.tzw
       - run: opam exec -- why3 prove -P z3 examples/dexter2/liquidity.tzw 

--- a/examples/neg/entrypoints.tzw
+++ b/examples/neg/entrypoints.tzw
@@ -18,7 +18,7 @@ end
 
 scope Alice
 
-  type storage = address
+  type storage [@gen_wf] = address
 
   predicate pre (_st : step) (_gp : gparam) (c : ctx) = inv_pre c
 
@@ -39,7 +39,7 @@ end
 
 scope Bob
 
-  type storage = address
+  type storage [@gen_wf] = address
 
   predicate pre (_st : step) (_gp : gparam) (c : ctx) = inv_pre c
 
@@ -59,7 +59,7 @@ end
 
 scope Carol
 
-  type storage = address
+  type storage [@gen_wf] = address
 
   predicate pre (_st : step) (_gp : gparam) (c : ctx) = inv_pre c
 

--- a/examples/test_balance.tzw
+++ b/examples/test_balance.tzw
@@ -1,0 +1,54 @@
+(*
+  `ctx.[contract_name]_balance` is the balance of the contract
+  without the amount of the current transfer.
+  `st.balance` corresponds to the `BALANCE` operation of Michelson,
+  including the amount of the current transfer.
+*)
+
+scope Postambles
+  predicate inv (c : ctx) =
+    c.a_storage = A.{ acc = c.a_balance; diff = 0 }
+end
+
+scope Unknown
+
+  predicate pre (c : ctx) = inv c
+
+  predicate post (_c : ctx) (c' : ctx) = inv c'
+
+  scope Entrypoint
+
+  predicate default unit
+
+  end
+
+end
+
+scope A
+
+  type storage [@gen_wf] = {
+    acc : mutez;
+    diff : mutez
+  }
+
+  predicate pre (_st : step) (_gp : gparam) (c : ctx) = inv c
+
+  predicate post (st : step) (_gp : gparam) (c : ctx) (c' : ctx) =
+    st.balance = c.a_balance + st.amount /\
+    c'.a_balance = c.a_balance + st.amount /\
+    inv c'
+
+  let upper_ops = 1
+
+  scope Spec
+
+    predicate default (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
+      let acc' = s.acc + st.amount in
+      let abs a b = if a > b then a - b else b - a in
+      s' = { acc = acc'; diff = s.diff + abs acc' st.balance } /\
+      ops = Nil
+
+  end
+
+end
+

--- a/lib/mlw/preambles.mlw
+++ b/lib/mlw/preambles.mlw
@@ -78,6 +78,7 @@ type step =
     sender: address;
     self: address;
     amount: mutez;
+    balance: mutez;
     level: nat;
     now: timestamp
   }
@@ -87,12 +88,14 @@ function mk_step
     (sender : address)
     (self : address)
     (amount : mutez)
+    (balance : mutez)
     (level : nat)
     (now : timestamp) : step =
   { source= source;
     sender= sender;
     self= self;
     amount= amount;
+    balance= balance;
     level= level;
     now= now }
 


### PR DESCRIPTION
This MR introduces the `st.balance` parameter, which corresponds to the `BALANCE` Michelson op.
This MR adds the following codes.
- When dispatching, the assumption `st.balance = c.[dst_contract_name]_balance + st.amount` is added.
- The requirement `st.balance = c.[contract_name]_balance + st.amount` is added as the `require` closue of each `contract_func`s.
- When processing `Xfer` op in the contracts, the `st.balance` field is initialized with the appropriate value. (For the unknown case, I initialized it with 0 for now.)

This MR also adds https://github.com/satos---jp/icon-why3/blob/satos%40add-balance/examples/test_balance.tzw which tests `st.balance`.

(In addition, this MR contains a commit irrelevant to `st.balance`, which fixes https://github.com/satos---jp/icon-why3/blob/satos%40add-balance/examples/neg/entrypoints.tzw )