### PR TITLE
Improvements around gparam

### DIFF
--- a/examples/auction.tzw
+++ b/examples/auction.tzw
@@ -62,12 +62,12 @@ scope Auction
 
   predicate withdraw (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
     s' = { s with pending_returns = s.pending_returns[st.sender <- 0] } /\
-    ops = Cons (Xfer (Gp'Unknown'default ()) s.pending_returns[st.sender] st.sender) Nil
+    ops = Cons (Xfer (ICon.Gp (() : unit)) s.pending_returns[st.sender] st.sender ICon.Contract.Default) Nil
 
   predicate end_auction (_st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
     not s.ended /\
     s' = { s with ended = true } /\
-    ops = Cons (Xfer (Gp'Unknown'default ()) s.highest_bid s.beneficiary) Nil
+    ops = Cons (Xfer (ICon.Gp (() : unit)) s.highest_bid s.beneficiary ICon.Contract.Default) Nil
 
   end
 

--- a/examples/boomerang.tzw
+++ b/examples/boomerang.tzw
@@ -27,8 +27,7 @@ scope Boomerang
 
   predicate default (st : step) (_p : unit) (_s : storage) (ops : list operation) (_s' : storage) =
     (st.amount = 0 -> ops = Nil) /\
-    (st.amount > 0 -> ops = Cons (Xfer (Gp'Unknown'default ()) st.amount st.sender) Nil)
-
+    (st.amount > 0 -> ops = Cons (Xfer (ICon.Gp (() : unit)) st.amount st.sender ICon.Contract.Default) Nil)
   end
 
 end

--- a/examples/boomerang_acc.tzw
+++ b/examples/boomerang_acc.tzw
@@ -29,7 +29,7 @@ scope Boomerang
   predicate default (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
     s' = s + st.amount /\
     (st.amount = 0 -> ops = Nil) /\
-    (st.amount > 0 -> ops = Cons (Xfer (Gp'Unknown'default ()) st.amount st.sender) Nil)
+    (st.amount > 0 -> ops = Cons (Xfer (ICon.Gp (() : unit)) st.amount st.sender ICon.Contract.Default) Nil)
 
   end
 

--- a/examples/callback.tzw
+++ b/examples/callback.tzw
@@ -11,12 +11,12 @@ scope Postambles
 
   predicate post_caller_inv (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     addr_inv c' /\
-    match gp with
-    | Gp'0callback'0nat param ->
+    match gp, st.entrypoint with
+    | ICon.Gp (param : nat), ICon.Contract.Callback ->
         st.sender = Callee.addr /\
         c'.caller_storage.Caller.counter = c.caller_storage.Caller.counter /\
         c'.caller_storage.Caller.response = param
-    | Gp'0update'0nat _param ->
+    | ICon.Gp (_param : nat), ICon.Contract.Update ->
         cnt_resp_inv c'
     | _ -> true
     end
@@ -27,8 +27,8 @@ scope Postambles
 
   predicate post_callee_inv (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     addr_inv c' /\
-    match gp with
-    | Gp'0oracle'0nat param ->
+    match gp, st.entrypoint with
+    | ICon.Gp (param : nat), ICon.Contract.Oracle ->
         if st.sender = Caller.addr then
           c'.caller_storage.Caller.response = param + 123 /\
           c'.caller_storage.Caller.counter = c.caller_storage.Caller.counter
@@ -72,7 +72,7 @@ scope Caller
 
     predicate update (_st : step) (p : nat) (s : storage) (ops : list operation) (s' : storage) =
       s' = { s with counter = p } /\
-      ops = Cons (Xfer (Gp'Callee'oracle p) 0 s.callee_addr) Nil
+      ops = Cons (Xfer (ICon.Gp (p : nat)) 0 s.callee_addr ICon.Contract.Oracle) Nil
 
     predicate callback (st : step) (p : nat) (s : storage) (ops : list operation) (s' : storage) =
       st.sender = s.callee_addr /\
@@ -97,7 +97,7 @@ scope Callee
 
     predicate oracle (st : step) (p : nat) (s : storage) (ops : list operation) (s' : storage) =
       s' = s /\
-      ops = Cons (Xfer (Gp'Caller'callback (p + 123)) 0 st.sender) Nil
+      ops = Cons (Xfer (ICon.Gp (p + 123 : nat)) 0 st.sender ICon.Contract.Callback) Nil
 
   end
 

--- a/examples/dexter2/liquidity.tzw
+++ b/examples/dexter2/liquidity.tzw
@@ -49,8 +49,8 @@ scope Postambles
     let total_record' = c'.cpmm_storage.Cpmm.lqt_total in
     let total_supply' = c'.lqt_storage.Lqt.total_supply in
     if st.sender = c.lqt_storage.Lqt.admin (* Cpmm.addr *) then
-      match gp with
-      | Gp'0mintOrBurn'0int4address quantity _ ->
+      match gp, st.entrypoint with
+      | ICon.Gp ((quantity, _) : (int, address)), ICon.Contract.MintOrBurn ->
           total_record' - total_supply' + quantity = total_record - total_supply
       | _ -> total_record' - total_supply' = total_record - total_supply
       end
@@ -98,62 +98,67 @@ scope Cpmm
 
   scope Spec
 
-  predicate add_liquidity (_st : step) (_p1 : address) (_p2 : nat) (_p3 : nat) (_p4 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate add_liquidity (_st : step) (_p : ((address, nat), (nat, timestamp))) (s : storage) (op : list operation) (s' : storage) =
     s.lqt_address <> null_addr /\
     s'.lqt_address = s.lqt_address /\
     let lqt_minted = s'.lqt_total - s.lqt_total in
     match op with
-    | Cons (Xfer (Gp'Unknown'transfer _) _ _)
-      (Cons (Xfer (Gp'Lqt'mintOrBurn q _) _ lqc) Nil) ->
+    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ _ ICon.Contract.Transfer)
+            (Cons (Xfer (ICon.Gp ((q, _) : (int, address))) _ lqc ICon.Contract.MintOrBurn)
+	     Nil) ->
       q = lqt_minted /\
       lqc = s.lqt_address
     | _ -> False
     end
 
-  predicate remove_liquidity (_st : step) (_p1 : address) (p2 : nat) (_p3 : mutez) (_p4 : nat) (_p5 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate remove_liquidity (_st : step) (p : (address, nat, mutez, nat, timestamp)) (s : storage) (op : list operation) (s' : storage) =
+    let (_, p2, _, _, _) = p in
     let lqt_burned = p2 in
     s.lqt_address <> null_addr /\
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total - lqt_burned /\
     match op with
-    | Cons (Xfer (Gp'Lqt'mintOrBurn q _) _ lqc)
-      (Cons (Xfer (Gp'Unknown'transfer _) _ _)
-       (Cons (Xfer (Gp'Unknown'default _) _ _) Nil)) ->
+    | Cons (Xfer (ICon.Gp ( (q, _) : (int, address) )) _ lqc ICon.Contract.MintOrBurn)
+      (Cons (Xfer (ICon.Gp ( _ : list (address, list (address, (nat, nat))))) _ _ ICon.Contract.Transfer)
+      (Cons (Xfer (ICon.Gp ( _ : unit)) _ _ ICon.Contract.Default)
+       Nil)) ->
       q = 0 - lqt_burned /\
       lqc = s.lqt_address
     | _ -> False
     end
 
-  predicate xtz_to_token (_st : step) (_p1 : address) (_p2 : nat) (_p3 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate xtz_to_token (_st : step) (_p : (address, nat, timestamp)) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-    | Cons (Xfer (Gp'Unknown'transfer _) _ _) Nil ->
+     | Cons (Xfer (ICon.Gp (_ : list (address, list (address, (nat, nat))))) _ _ ICon.Contract.Transfer) Nil ->
       True
     | _ -> False
     end
 
-  predicate token_to_xtz (_st : step) (_p1 : address) (_p2 : nat) (_p3 : mutez) (_p4 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate token_to_xtz (_st : step) (_p : (address, nat, mutez, timestamp)) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-    | Cons (Xfer (Gp'Unknown'transfer _) _ _)
-      (Cons (Xfer (Gp'Unknown'default _) _ _) Nil) ->
+    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ _ ICon.Contract.Transfer)
+            (Cons (Xfer (ICon.Gp (_ : unit)) _ _ ICon.Contract.Default)
+                   Nil) ->
       True
     | _ -> False
     end
 
-  predicate token_to_token (_st : step) (_p1 : address) (_p2 : nat) (_p3 : address) (_p4 : nat) (_p5 : timestamp) (s : storage) (op : list operation) (s' : storage) =
+  predicate token_to_token (_st : step) (_p : (address, nat, address, nat, timestamp)) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-    | Cons (Xfer (Gp'Unknown'transfer _) _ _)
-      (Cons (Xfer (Gp'Cpmm'xtz_to_token _ _ _) _ _) Nil) ->
+    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ _ ICon.Contract.Transfer)
+           (Cons (Xfer (ICon.Gp (_ : (address, nat, timestamp))) _ _ ICon.Contract.Xtz_to_token)
+	    Nil) ->
       True
     | _ -> False
     end
 
-  predicate set_baker (_st : step) (_p1 : option key_hash) (_p2 : bool) (s : storage) (op : list operation) (s' : storage) =
+  predicate set_baker (_st : step) (_p : (option key_hash, bool)) (s : storage) (op : list operation) (s' : storage) =
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
@@ -177,7 +182,7 @@ scope Cpmm
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-    | Cons (Xfer (Gp'Unknown'balance_of _) _ _) Nil ->
+    | Cons (Xfer (ICon.Gp (_ : unit)) _ _ ICon.Contract.Update_token_pool) Nil ->
       True
     | _ -> False
     end
@@ -216,7 +221,8 @@ scope Lqt
 
   scope Spec
 
-  predicate transfer (_st : step) (p1 : address) (p2 : address) (p3 : nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate transfer (_st : step) (p : (address, address, nat)) (s : storage) (op : list operation) (s' : storage) =
+    let (p1, p2, p3) = p in
     let address_from = p1 in
     let address_to = p2 in
     let value = p3 in
@@ -234,13 +240,14 @@ scope Lqt
     s'.tokens = tokens[address_to <- maybe_to_balance] /\
     op = Nil
 
-  predicate approve (_st : step) (_p1 : address) (_p2 : nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate approve (_st : step) (_p : (address, nat)) (s : storage) (op : list operation) (s' : storage) =
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
     op = Nil
 
-  predicate mintOrBurn (st : step) (quantity : int) (target : address) (s : storage) (op : list operation) (s' : storage) =
+  predicate mintOrBurn (st : step) (p : (int, address)) (s : storage) (op : list operation) (s' : storage) =
+    let (quantity, target) = p in
     st.sender = s.admin /\
     s'.total_supply = abs (s.total_supply + quantity) /\
     s'.admin = s.admin /\
@@ -251,35 +258,38 @@ scope Lqt
     let maybe_new_balance = if new_balance = 0 then None else Some new_balance in
     s'.tokens = s.tokens[target <- maybe_new_balance]
 
-  predicate getAllowance (_st : step) (_p1 : (address, address)) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate getAllowance (_st : step) (p : ((address, address), contract nat)) (s : storage) (op : list operation) (s' : storage) =
+    let (_p1, p2) = p in
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
     match op with
-    | Cons (Xfer _ _ c) Nil ->
+    | Cons (Xfer _ _ c ICon.Contract.Default) Nil ->
       c = callback
     | _ -> False
     end
 
-  predicate getBalance (_st : step) (_p1 : address) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate getBalance (_st : step) (p : (address, contract nat)) (s : storage) (op : list operation) (s' : storage) =
+    let (_p1, p2) = p in
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
     match op with
-    | Cons (Xfer _ _ c) Nil ->
+    | Cons (Xfer _ _ c ICon.Contract.Default) Nil ->
       c = callback
     | _ -> False
     end
 
-  predicate getTotalSupply (_st : step) (_p1 : unit) (p2 : contract nat) (s : storage) (op : list operation) (s' : storage) =
+  predicate getTotalSupply (_st : step) (p : (unit, contract nat)) (s : storage) (op : list operation) (s' : storage) =
+    let (_p1, p2) = p in
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
     match op with
-    | Cons (Xfer _ _ c) Nil ->
+    | Cons (Xfer _ _ c ICon.Contract.Default) Nil ->
       c = callback
     | _ -> False
     end

--- a/examples/neg/entrypoints.tzw
+++ b/examples/neg/entrypoints.tzw
@@ -18,7 +18,7 @@ end
 
 scope Alice
 
-  type storage = address
+  type storage [@gen_wf] = address
 
   predicate pre (_st : step) (_gp : gparam) (c : ctx) = inv_pre c
 
@@ -31,7 +31,7 @@ scope Alice
   predicate default (_st : step) (_p : unit) (s : storage) (ops : list operation) (_s' : storage) =
     (* This transaction seems to call only Carol, but in fact, it may call Bob because the call signature only consists of the entrypoint's name and parameter type. 
     As a result, this example should be unverified since Bob accept a call from Alice as specified in the invariant pre-condition. *)
-    (ops = Cons (Xfer (Gp'Carol'default ()) 1 s) Nil)
+    (ops = Cons (Xfer (ICon.Gp (() : unit)) 1 s ICon.Contract.Default) Nil)
 
   end
 
@@ -39,7 +39,7 @@ end
 
 scope Bob
 
-  type storage = address
+  type storage [@gen_wf] = address
 
   predicate pre (_st : step) (_gp : gparam) (c : ctx) = inv_pre c
 
@@ -59,7 +59,7 @@ end
 
 scope Carol
 
-  type storage = address
+  type storage [@gen_wf] = address
 
   predicate pre (_st : step) (_gp : gparam) (c : ctx) = inv_pre c
 

--- a/lib/dune
+++ b/lib/dune
@@ -4,11 +4,14 @@
 
 (rule
  (target preambles.ml)
- (deps mlw/preambles.mlw)
+ (deps mlw/preambles.mlw mlw/step.mlw)
  (action
   (with-stdout-to
    %{target}
    (progn
     (echo "let preambles = {preambles|")
-    (cat %{deps})
+    (cat mlw/preambles.mlw)
+    (echo "|preambles}")
+    (echo "let step = {preambles|")
+    (cat mlw/step.mlw)
     (echo "|preambles}")))))

--- a/lib/gen_mlw.ml
+++ b/lib/gen_mlw.ml
@@ -127,8 +127,7 @@ module T = struct
           Tbinnop (of_expr e1, Dterm.DTand, of_expr e2)
       | Eapply (e1, e2) -> Tapply (of_expr e1, of_expr e2)
       | _ ->
-          Format.eprintf "T.of_expr: unsupported: %a@."
-            (Mlw_printer.pp_expr ~attr:true).closed e;
+          Format.eprintf "T.of_expr: unsupported: %a@." Ptree_printer.pp_expr e;
           assert false
     in
     { term_desc; term_loc = e.expr_loc }
@@ -255,8 +254,7 @@ module Is_type_wf = struct
     | PTparen pty -> gen_expr pty
     | _ ->
         failwith
-          (Format.asprintf "is_type_wf: Unsupported type %a"
-             (Mlw_printer.pp_pty ~attr:true).closed pty)
+          (Format.asprintf "is_type_wf: Unsupported type %a" Ptree_printer.pp_pty pty)
 
   (* [is_type_wf e] *)
   let gen_apply pty e =
@@ -313,9 +311,7 @@ module Is_type_wf = struct
           in
           return @@ term @@ Tcase (term @@ Tident (qid v_id), cases)
       | _ ->
-          error_with ~loc "Unsupported %a@."
-            (Mlw_printer.pp_decl ~attr:true)
-            (Dtype [ type_decl ])
+          error_with ~loc "Unsupported %a@." Ptree_printer.pp_decl (Dtype [ type_decl ])
     in
     let v_param : param =
       ( Loc.dummy_position,

--- a/lib/mlw/preambles.mlw
+++ b/lib/mlw/preambles.mlw
@@ -13,6 +13,24 @@ predicate is__tuple2_wf (is_a_wf : 'a -> bool) (is_b_wf : 'b -> bool) (ab : ('a,
   let (a,b) = ab in
   is_a_wf a /\ is_b_wf b
 
+predicate is__tuple3_wf (is_a_wf : 'a -> bool) (is_b_wf : 'b -> bool) (is_c_wf : 'c -> bool) (abc : ('a, 'b, 'c)) =
+  let (a,b,c) = abc in
+  is_a_wf a /\ is_b_wf b /\ is_c_wf c
+
+predicate is__tuple4_wf (is_a_wf : 'a -> bool) (is_b_wf : 'b -> bool) (is_c_wf : 'c -> bool) (is_d_wf : 'd -> bool) (abcd : ('a, 'b, 'c, 'd)) =
+  let (a,b,c,d) = abcd in
+  is_a_wf a /\ is_b_wf b /\ is_c_wf c /\ is_d_wf d
+
+predicate is__tuple5_wf
+  (is_a_wf : 'a -> bool)
+  (is_b_wf : 'b -> bool)
+  (is_c_wf : 'c -> bool)
+  (is_d_wf : 'd -> bool)
+  (is_e_wf : 'e -> bool)
+  (abcde : ('a, 'b, 'c, 'd, 'e)) =
+  let (a,b,c,d,e) = abcde in
+  is_a_wf a /\ is_b_wf b /\ is_c_wf c /\ is_d_wf d /\ is_e_wf e
+
 predicate is_list_wf (_ : 'a -> bool) (_ : list 'a) = true
 
 predicate is_unit_wf (_ : unit) = true
@@ -72,29 +90,3 @@ predicate is_or_wf (is_a_wf : 'a -> bool) (is_b_wf : 'b -> bool) (ab : or 'a 'b)
 type lambda 'a 'b = 'a -> 'b
 
 predicate is_lambda_wf (_ : 'a -> bool) (_ : 'b -> bool) (_ : lambda 'a 'b) = true
-
-type step =
-  { source: address;
-    sender: address;
-    self: address;
-    amount: mutez;
-    level: nat;
-    now: timestamp
-  }
-
-function mk_step
-    (source : address)
-    (sender : address)
-    (self : address)
-    (amount : mutez)
-    (level : nat)
-    (now : timestamp) : step =
-  { source= source;
-    sender= sender;
-    self= self;
-    amount= amount;
-    level= level;
-    now= now }
-
-predicate step_wf (st : step) =
-  st.amount >= 0

--- a/lib/mlw/step.mlw
+++ b/lib/mlw/step.mlw
@@ -1,0 +1,28 @@
+type step =
+  { source: address;
+    sender: address;
+    self: address;
+    entrypoint: ICon.Contract.entrypoint; (* type entrypoint must be generated *)
+    amount: mutez;
+    level: nat;
+    now: timestamp
+  }
+
+function mk_step
+    (source : address)
+    (sender : address)
+    (self : address)
+    (entrypoint : ICon.Contract.entrypoint)
+    (amount : mutez)
+    (level : nat)
+    (now : timestamp) : step =
+  { source= source;
+    sender= sender;
+    self= self;
+    entrypoint= entrypoint;
+    amount= amount;
+    level= level;
+    now= now }
+
+predicate step_wf (st : step) =
+  st.amount >= 0

--- a/lib/ptree_printer.ml
+++ b/lib/ptree_printer.ml
@@ -1,0 +1,8 @@
+open Why3
+
+type 'a t = Format.formatter -> 'a -> unit
+
+let pp_expr = (Mlw_printer.pp_expr ~attr:true).closed
+let pp_term = (Mlw_printer.pp_term ~attr:true).closed
+let pp_pty = (Mlw_printer.pp_pty ~attr:true).closed
+let pp_decl = Mlw_printer.pp_decl ~attr:true

--- a/lib/ptree_printer.mli
+++ b/lib/ptree_printer.mli
@@ -1,0 +1,9 @@
+open Why3
+open Ptree
+
+type 'a t = Format.formatter -> 'a -> unit
+
+val pp_expr : expr t
+val pp_term : term t
+val pp_pty : pty t
+val pp_decl : decl t

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -157,7 +157,7 @@ let rec sort_of_pty (pty : pty) : t iresult =
       let* sl = List.map_e sort_of_pty ptys in
       return @@ S_tuple sl
   | PTparen pty -> sort_of_pty pty
-  | _ -> error_with "unknown sort %a" (Mlw_printer.pp_pty ~attr:true).closed pty
+  | _ -> error_with "unknown sort %a" Ptree_printer.pp_pty pty
 
 let rec pty_of_sort (s : t) : Ptree.pty =
   let ty s = PTtyapp (qualid [ s ], []) in

--- a/lib/tzw.ml
+++ b/lib/tzw.ml
@@ -219,8 +219,7 @@ let parse_contract loc id ds =
         | Dlogic _ -> return (ostore, okont, oeps, opre, opost)
         | decl ->
             error_with ~loc "@[<2>unexpected declaration:@ %a@]"
-              (Mlw_printer.pp_decl ~attr:true)
-              decl)
+              Ptree_printer.pp_decl decl)
       (None, None, None, None, None)
       ds
   in

--- a/lib/tzw.ml
+++ b/lib/tzw.ml
@@ -15,7 +15,7 @@ let is_storage_type (pty : Ptree.pty) : bool = is_id_type pty Id.storage_ty
 
 type entrypoint_params = {
   epp_step : param;
-  epp_param : param list;
+  epp_param : param;
   epp_old_s : param;
   epp_new_s : param;
   epp_ops : param;
@@ -41,27 +41,20 @@ type t = {
   tzw_preambles : decl list;
   tzw_postambles : decl list;
   tzw_knowns : contract list;
-  tzw_epp : Sort.t list StringMap.t StringMap.t;
+  tzw_epp : Sort.t StringMap.t StringMap.t;
+      (* contract -> entrypoint -> parameter *)
   tzw_unknown_pre : logic_decl;
   tzw_unknown_post : logic_decl;
 }
 
-(** entrypoint params are "(st : step) (p1 : t1) ... (pn : tn) (s : store) (ops : list operation) (s' : store)", where "t1 ... tn" must be a michelson type. *)
-let parse_entrypoint_params (params : param list) =
+(** entrypoint params are "(st : step) (p : t) (s : store) (ops : list operation) (s' : store)", where "t" must be a michelson type. *)
+let parse_entrypoint_params ~loc (params : param list) =
   let param_loc (l, _, _, _) = l in
   let param_pty (_, _, _, pty) = pty in
-  let* st, params =
+  let* st, param, s, op, s' =
     match params with
-    | x :: xs -> return (x, xs)
-    | _ -> error_with "invalid format: parameters"
-  in
-  let* s, s', op, params =
-    let rec aux params = function
-      | [ s; op; s' ] -> return (s, s', op, List.rev params)
-      | x :: (_ :: _ :: _ :: _ as xs) -> aux (x :: params) xs
-      | _ -> error_with "invalid format: parameters"
-    in
-    aux [] params
+    | [ st; param; s; op; s' ] -> return (st, param, s, op, s')
+    | _ -> error_with ~loc "invalid format: parameters"
   in
   let* () =
     error_unless
@@ -98,23 +91,17 @@ let parse_entrypoint_params (params : param list) =
         (error_of_fmt ~loc:(param_loc op)
            "invalid format: list operation type is expected")
   in
-  let* () =
-    List.fold_left_e
-      (fun () p ->
-        let* _ =
-          trace
-            ~err:
-              (error_of_fmt ~loc:(param_loc p)
-                 "invalid format: Michelson type is expected")
-          @@ Sort.sort_of_pty @@ param_pty p
-        in
-        return ())
-      () params
+  let* _ =
+    trace
+      ~err:
+        (error_of_fmt ~loc:(param_loc param)
+           "invalid format: Michelson type is expected")
+    @@ Sort.sort_of_pty @@ param_pty param
   in
   return
     {
       epp_step = st;
-      epp_param = params;
+      epp_param = param;
       epp_old_s = s;
       epp_new_s = s';
       epp_ops = op;
@@ -123,7 +110,7 @@ let parse_entrypoint_params (params : param list) =
 let parse_entrypoint_pred (ld : logic_decl) : entrypoint iresult =
   let ep_loc = ld.ld_loc in
   let ep_name = ld.ld_ident in
-  let* ep_params = parse_entrypoint_params ld.ld_params in
+  let* ep_params = parse_entrypoint_params ~loc:ld.ld_loc ld.ld_params in
   let* () =
     error_unless (ld.ld_type = None)
       ~err:(error_of_fmt ~loc:ep_loc "invalid format: predicate is expected")
@@ -134,6 +121,7 @@ let parse_entrypoint_pred (ld : logic_decl) : entrypoint iresult =
   in
   return { ep_loc; ep_name; ep_params; ep_body }
 
+(* Parse [scope Spec predicate entry_point ... end] *)
 let parse_entrypoint_scope (lds : decl list) =
   List.fold_left_e
     (fun tl d ->
@@ -257,16 +245,17 @@ let parse_contract loc id ds =
     { c_name = id; c_entrypoints; c_num_kont; c_pre; c_post; c_other_decls }
 
 let parse_unknown (loc : Loc.position) (ds : decl list) =
-  let parse_entrypoint_type (ds : decl list) =
+  let parse_entrypoint_type (ds : Ptree.decl list) : Sort.t StringMap.t iresult
+      =
     List.fold_left_e
       (fun m -> function
         | Dlogic [ ld ] ->
-            let* s =
-              List.map_e
-                (fun (loc, _, _, pty) ->
+            let* (s : Sort.t) =
+              match ld.ld_params with
+              | [ (loc, _, _, pty) ] ->
                   trace ~err:(error_of_fmt ~loc "Michelson type is expected")
-                  @@ Sort.sort_of_pty pty)
-                ld.ld_params
+                  @@ Sort.sort_of_pty pty
+              | _ -> error_with ~loc:ld.ld_loc "Michelson type is expected"
             in
             return @@ StringMap.add ld.ld_ident.id_str s m
         | _ ->
@@ -346,11 +335,8 @@ let parse_mlw (mlw : mlw_file) =
         let* epp =
           List.fold_left_e
             (fun m ep ->
-              let* s =
-                List.map_e
-                  (fun (_, _, _, pty) -> Sort.sort_of_pty pty)
-                  ep.ep_params.epp_param
-              in
+              let _, _, _, pty = ep.ep_params.epp_param in
+              let* s = Sort.sort_of_pty pty in
               return @@ StringMap.add ep.ep_name.id_str s m)
             StringMap.empty c.c_entrypoints
         in

--- a/lib/tzw.mli
+++ b/lib/tzw.mli
@@ -5,7 +5,7 @@ open Error_monad
 
 type entrypoint_params = {
   epp_step : param;
-  epp_param : param list;
+  epp_param : param;
   epp_old_s : param;
   epp_new_s : param;
   epp_ops : param;
@@ -31,8 +31,9 @@ type t = {
   tzw_preambles : decl list;
   tzw_postambles : decl list;
   tzw_knowns : contract list;
-  tzw_epp : Sort.t list StringMap.t StringMap.t;
-      (** contract name ↦ (entrypoint name ↦ sorts of parameters) *)
+  tzw_epp : Sort.t StringMap.t StringMap.t;
+      (** Entrypoint parameters:
+        contract name ↦ (entrypoint name ↦ sort of parameter) *)
   tzw_unknown_pre : logic_decl;
   tzw_unknown_post : logic_decl;
 }


### PR DESCRIPTION
Implements some ideas described in https://github.com/westpaddy/icon-why3/blob/nishida/contract-ty/req/gparam.md

    - [ICon.Gp (v : ty)] for Gparam constructor. The type annotation is required.
    - [ICon.Contract.<Entrypoint>] for entrypoint selector.
    - [Xfer] is extended with another argument of the entrypoint
    - [step] is extneded with a field [entrypoint] for the current entrypoint.

Unfortunately callback.tzw does not verify for the moment.

