### PR TITLE
Implement the feature to convert ICon.Contract

### DIFF
--- a/examples/auction.tzw
+++ b/examples/auction.tzw
@@ -62,12 +62,12 @@ scope Auction
 
   predicate withdraw (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
     s' = { s with pending_returns = s.pending_returns[st.sender <- 0] } /\
-    ops = Cons (Xfer (ICon.Gp (() : unit)) s.pending_returns[st.sender] st.sender ICon.Contract.Default) Nil
+    ops = Cons (Xfer (ICon.Gp (() : unit)) s.pending_returns[st.sender] (ICon.Contract st.sender)) Nil
 
   predicate end_auction (_st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
     not s.ended /\
     s' = { s with ended = true } /\
-    ops = Cons (Xfer (ICon.Gp (() : unit)) s.highest_bid s.beneficiary ICon.Contract.Default) Nil
+    ops = Cons (Xfer (ICon.Gp (() : unit)) s.highest_bid (ICon.Contract s.beneficiary)) Nil
 
   end
 

--- a/examples/boomerang.tzw
+++ b/examples/boomerang.tzw
@@ -27,7 +27,7 @@ scope Boomerang
 
   predicate default (st : step) (_p : unit) (_s : storage) (ops : list operation) (_s' : storage) =
     (st.amount = 0 -> ops = Nil) /\
-    (st.amount > 0 -> ops = Cons (Xfer (ICon.Gp (() : unit)) st.amount st.sender ICon.Contract.Default) Nil)
+    (st.amount > 0 -> ops = Cons (Xfer (ICon.Gp (() : unit)) st.amount (ICon.Contract st.sender)) Nil)
   end
 
 end

--- a/examples/boomerang_acc.tzw
+++ b/examples/boomerang_acc.tzw
@@ -29,7 +29,7 @@ scope Boomerang
   predicate default (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
     s' = s + st.amount /\
     (st.amount = 0 -> ops = Nil) /\
-    (st.amount > 0 -> ops = Cons (Xfer (ICon.Gp (() : unit)) st.amount st.sender ICon.Contract.Default) Nil)
+    (st.amount > 0 -> ops = Cons (Xfer (ICon.Gp (() : unit)) st.amount (ICon.Contract st.sender)) Nil)
 
   end
 

--- a/examples/callback.tzw
+++ b/examples/callback.tzw
@@ -72,7 +72,7 @@ scope Caller
 
     predicate update (_st : step) (p : nat) (s : storage) (ops : list operation) (s' : storage) =
       s' = { s with counter = p } /\
-      ops = Cons (Xfer (ICon.Gp (p : nat)) 0 s.callee_addr ICon.Contract.Oracle) Nil
+      ops = Cons (Xfer (ICon.Gp (p : nat)) 0 (ICon.Contract.oracle s.callee_addr)) Nil
 
     predicate callback (st : step) (p : nat) (s : storage) (ops : list operation) (s' : storage) =
       st.sender = s.callee_addr /\
@@ -97,7 +97,7 @@ scope Callee
 
     predicate oracle (st : step) (p : nat) (s : storage) (ops : list operation) (s' : storage) =
       s' = s /\
-      ops = Cons (Xfer (ICon.Gp (p + 123 : nat)) 0 st.sender ICon.Contract.Callback) Nil
+      ops = Cons (Xfer (ICon.Gp (p + 123 : nat)) 0 (ICon.Contract.callback st.sender)) Nil
 
   end
 

--- a/examples/dao.tzw
+++ b/examples/dao.tzw
@@ -1,10 +1,9 @@
 scope Preambles
   meta "algebraic:kept" type (nat, address)
   meta "algebraic:kept" type option (nat, address)
-
-
+  
   type poll [@gen_wf] = {
-    proposal : lambda unit unit; (* lambda unit (list operation) *)
+    proposal : lambda unit nat; (* lambda unit (list operation) *)
     author : address;
     votingStartBlock : nat;
     votingEndBlock : nat;
@@ -80,9 +79,9 @@ scope DAO
           voters=empty_set}
     }
     *)
-    (* predicate propose
+    predicate propose
       (st : step)
-      (proposalLambda : lambda unit operation)
+      (proposalLambda : lambda unit nat)
       (s : storage)
       (ops : list operation)
       (s' : storage) =
@@ -104,7 +103,7 @@ scope DAO
           in
           s' = { s with poll = poll }
       | Some _ -> False
-      end *)
+      end
 
     (*
     entrypoint endVote ()
@@ -122,7 +121,7 @@ scope DAO
       }
     }
     *)
-    (* predicate endVoting
+    predicate endVoting
       (st : step)
       (_p : unit)
       (s : storage)
@@ -137,9 +136,10 @@ scope DAO
           let op = Xfer (ICon.Gp ((self st, poll.author, s.escrowAmount) : (address, address, nat))) 0 (ICon.Contract.transfer s.tokenAddress) in
           { s with poll = None } = s' /\
           ops = if yayVotesNeededForSuperMajority <= poll.yayVotes * 100
-                  then Cons op (Cons (poll.proposal ()) Nil) (* p.proposal *)
+                  then let _ = poll.proposal () in Cons op Nil
+                  (* then Cons op (Cons (poll.proposal ()) Nil) *)
                   else Cons op Nil
-      end *)
+      end
 
     (*
     entrypoint vote (voteValue) (* voteValue... 0 for yay, 1 for nay, 2 for abstain *)
@@ -223,14 +223,15 @@ scope Token
     approvals : map address (map address nat);
   }
 
-  predicate pre (st : step) (_gp : gparam) (c : ctx) =
+  predicate pre (st : step) (gp : gparam) (c : ctx) =
     addr_inv c /\
-    match _gp with
-    | ICon.Gp (p : (address, contract)) ->
+    match st.entrypoint, gp with
+    | ICon.Contract.GetBalance, ICon.Gp (p : (address, contract)) ->
         (st.sender <> DAO.addr -> storage_inv c) /\
         (st.sender = DAO.addr ->
           let addr, callback = p in
           callback = ICon.Contract.voteCallback st.sender)
+    | ICon.Contract.Transfer, ICon.Gp (p : (address, address, nat)) -> storage_inv c
     | _ -> false
     end
 
@@ -239,7 +240,7 @@ scope Token
   let upper_ops = 1
 
   scope Spec
-    (* predicate transfer
+    predicate transfer
       (st : step)
       (p : (address, address, nat))
       (s : storage)
@@ -256,12 +257,12 @@ scope Token
       let b' = s'.balances[from_ <- from_balance] in
       b = b' /\
 
-      if sender <> s.admin /\ sender <> from_
-      then s'.approvals[from_][sender] + value = s.approvals[from_][sender]
-      else True /\
+      (if sender <> s.admin /\ sender <> from_
+        then s'.approvals[from_][sender] + value = s.approvals[from_][sender]
+        else True) /\
       s.admin = s'.admin /\
       s.approvals = s'.approvals /\
-      ops = Nil *)
+      ops = Nil
 
     predicate getBalance
       (st : step)

--- a/examples/dao.tzw
+++ b/examples/dao.tzw
@@ -1,0 +1,290 @@
+scope Preambles
+  meta "algebraic:kept" type (nat, address)
+  meta "algebraic:kept" type option (nat, address)
+
+
+  type poll [@gen_wf] = {
+    proposal : lambda unit unit; (* lambda unit (list operation) *)
+    author : address;
+    votingStartBlock : nat;
+    votingEndBlock : nat;
+    yayVotes : nat;
+    nayVotes : nat;
+    abstainVotes : nat;
+    totalVotes : nat;
+    voters : map address bool
+  }
+  meta "algebraic:kept" type option poll
+  meta "algebraic:kept" type (option (nat, address), option poll)
+end
+
+scope Postambles
+  predicate addr_inv (c : ctx) =
+    c.dAO_storage.DAO.tokenAddress = Token.addr
+
+  predicate storage_inv (c : ctx) =
+    c.dAO_storage.DAO.voteState = None
+end
+
+scope Unknown
+
+  predicate pre (c : ctx) =
+    addr_inv c /\
+    storage_inv c
+
+  predicate post (_c : ctx) (c' : ctx) =
+    addr_inv c' /\
+    storage_inv c'
+
+  scope Entrypoint
+
+  predicate default unit
+
+  end
+
+end
+
+scope DAO
+
+  type storage [@gen_wf] = {
+    poll : option poll;
+    tokenAddress : address; (* FA2 *)
+    escrowAmount : nat; (* poll のための deposit *)
+    voteLength : nat;
+    percentageForSuperMajority : nat;
+    voteState : option (nat, address);
+  }
+
+  predicate pre (st : step) (gp : gparam) (c : ctx) =
+    match st.entrypoint, gp with
+    | ICon.Contract.VoteCallback, ICon.Gp (p : (nat, address)) ->
+        st.sender <> Token.addr -> storage_inv c
+    | _ -> storage_inv c
+    end /\ addr_inv c
+
+  predicate post (_st : step) (_gp : gparam) (c : ctx) (c' : ctx) = inv_post c c'
+
+  let upper_ops = 2
+
+  scope Spec
+    (*
+    entrypoint propose (proposal)
+    {
+      assert(poll == None)
+      (* endVote を呼ばせるためのインセンティブ && proposal を出せる資格? *)
+      transfer(tokenAddress%transfer, 0, {from = sender, txs = [{to_ = self_address, amount = escrowAmount, token_id=0}]})
+      poll = Some
+        { proposal, author = sender
+          votingStartBlock=level, votingEndBlock = level+voteLength,
+          yayVotes=0, nayVotes=0, abstainVotes=0, totalVotes=0,
+          voters=empty_set}
+    }
+    *)
+    (* predicate propose
+      (st : step)
+      (proposalLambda : lambda unit operation)
+      (s : storage)
+      (ops : list operation)
+      (s' : storage) =
+      ops = Nil /\
+      match s.poll with
+      | None ->
+          let level = level st in
+          let poll = Some
+            { proposal = proposalLambda;
+              author = sender st;
+              votingStartBlock = level;
+              votingEndBlock = level + s.voteLength;
+              yayVotes = 0;
+              nayVotes = 0;
+              abstainVotes = 0;
+              totalVotes = 0;
+              voters = fun _ -> False
+            }
+          in
+          s' = { s with poll = poll }
+      | Some _ -> False
+      end *)
+
+    (*
+    entrypoint endVote ()
+    {
+      assert(is_some(poll))
+      let Some p = poll in
+      assert(p.votingEndBlock < level)
+      totalOpinionatedVotes = p.yayVotes + p.nayVotes
+      (* yayVotesNeededForEscrowReturn = totalOpinionatedVotes * minYayVotesPercentForEscrowReturn / 100 (* 一定の支持を得られなければボッシュート *) *)
+      yayVotesNeededForSuperMajority = totalOpinionatedVotes * percentageForSuperMajority / 100
+      transfer(tokenAddress%transfer, 0, {from = self_address, txs=[{to_=p.sender, amount=escrowAmount, token_id=0}]})
+      if(yayVotesNeededForSuperMajority <= yayVotes (* && quorum <= p.totalVotes *))
+      {
+        p.proposal ()
+      }
+    }
+    *)
+    (* predicate endVoting
+      (st : step)
+      (_p : unit)
+      (s : storage)
+      (ops : list operation)
+      (s' : storage) =
+      match s.poll with
+      | None -> False
+      | Some poll ->
+          poll.votingEndBlock < level st /\
+          let totalOpinionatedVotes = poll.yayVotes + poll.nayVotes in
+          let yayVotesNeededForSuperMajority = totalOpinionatedVotes * s.percentageForSuperMajority in
+          let op = Xfer (ICon.Gp ((self st, poll.author, s.escrowAmount) : (address, address, nat))) 0 (ICon.Contract.transfer s.tokenAddress) in
+          { s with poll = None } = s' /\
+          ops = if yayVotesNeededForSuperMajority <= poll.yayVotes * 100
+                  then Cons op (Cons (poll.proposal ()) Nil) (* p.proposal *)
+                  else Cons op Nil
+      end *)
+
+    (*
+    entrypoint vote (voteValue) (* voteValue... 0 for yay, 1 for nay, 2 for abstain *)
+    {
+      assert(voteState == None)
+      voteState = Some { voteValue, address=sender }
+      transfer((* escrowAddress%getBalance *) tokenAddress%getBalance, 0, { address, callback=voteCallback })
+    }
+     *)
+    predicate vote
+      (st : step)
+      (voteValue : nat)
+      (s : storage)
+      (ops : list operation)
+      (s' : storage) =
+      match s.voteState with
+      | Some _ -> true
+      | None ->
+          let addr = sender st in
+          { s with voteState = Some (voteValue, addr) } = s' /\
+          let callback = ICon.Contract.voteCallback (self st) in
+          ops = Cons (Xfer (ICon.Gp ((addr, callback) : (address, contract))) 0 (ICon.Contract.getBalance s.tokenAddress)) Nil
+      end
+
+    (*
+    entrypoint voteCallback(balance)
+    {
+      assert (is_some (voteState))
+      assert (is_some (p))
+      let Some vote = voteState in
+      let Some p = poll in
+      assert (level < p.votingEndBlock)
+      if (p.voters.mem(vote.address)) assert false (* 投票済み *)
+      p.voters.add(vote.address)
+      p.totalVotes += balance
+      if (vote.voteValue == 0) p.yayVotes += balance
+      else if (vote.voteValue == 1) p.nayVotes += balance
+      else if (vote.voteValue == 2) p.abstainVotes += balance
+      else assert false
+      poll = Some p
+      voteState = None
+    }
+     *)
+
+    predicate voteCallback
+      (st : step)
+      (p : (nat, address))
+      (s : storage)
+      (ops : list operation)
+      (s' : storage) =
+      let (value, addr) = p in
+      match (s.voteState, s.poll) with
+      | Some (voteValue, addr), Some poll ->
+          level st < poll.votingEndBlock /\
+          poll.voters[addr] /\
+          let totalVotes = poll.totalVotes + value in
+          let yayVotes = if voteValue = 0 then poll.yayVotes + value else poll.yayVotes in
+          let nayVotes = if voteValue = 1 then poll.nayVotes + value else poll.nayVotes in
+          let abstainVotes = if voteValue = 2 then poll.abstainVotes + value else poll.abstainVotes in
+          let voters = poll.voters[addr <- True] in
+          let poll =
+            Some
+              { poll with yayVotes = yayVotes
+              ; nayVotes = nayVotes
+              ; abstainVotes = abstainVotes
+              ; totalVotes = totalVotes
+              ; voters = voters }
+          in
+          { s with voteState = None; poll = poll } = s' /\
+          ops = Nil
+      | _ -> false
+      end
+  end
+
+end
+
+scope Token
+  type storage [@gen_wf] = {
+    balances : map (address) nat;
+    admin : address;
+    approvals : map address (map address nat);
+  }
+
+  predicate pre (st : step) (_gp : gparam) (c : ctx) =
+    addr_inv c /\
+    match _gp with
+    | ICon.Gp (p : (address, contract)) ->
+        (st.sender <> DAO.addr -> storage_inv c) /\
+        (st.sender = DAO.addr ->
+          let addr, callback = p in
+          callback = ICon.Contract.voteCallback st.sender)
+    | _ -> false
+    end
+
+  predicate post (_st : step) (_gp : gparam) (c : ctx) (c' : ctx) = inv_post c c'
+
+  let upper_ops = 1
+
+  scope Spec
+    (* predicate transfer
+      (st : step)
+      (p : (address, address, nat))
+      (s : storage)
+      (ops : list operation)
+      (s' : storage) =
+      let from_, to_, value = p in
+      let sender = sender st in
+      (from_ = sender \/ sender = s.admin \/ s.approvals[from_][sender] >= value) /\
+      
+      s.balances[from_] >= value /\
+      let to_balance = s.balances[to_] + value in
+      let b = s.balances[to_ <- to_balance] in
+      let from_balance = s'.balances[from_] + value in
+      let b' = s'.balances[from_ <- from_balance] in
+      b = b' /\
+
+      if sender <> s.admin /\ sender <> from_
+      then s'.approvals[from_][sender] + value = s.approvals[from_][sender]
+      else True /\
+      s.admin = s'.admin /\
+      s.approvals = s'.approvals /\
+      ops = Nil *)
+
+    predicate getBalance
+      (st : step)
+      (p : (address, contract))
+      (s : storage)
+      (ops : list operation)
+      (s' : storage) =
+      let addr, callback = p in
+      let value = s.balances[addr] in
+      ops = Cons (Xfer (ICon.Gp ((value, addr) : (nat, address))) 0 callback) Nil /\
+      s = s'
+  
+    (* predicate mint
+      (st : step)
+      (p : (address, nat))
+      (s : storage)
+      (ops : list operation)
+      (s' : storage) =
+      let addr, value = p in
+      sender st = s.admin /\
+      ops = Nil /\
+      let v = s.balances[addr] + value in
+      s' = { s with balances = s.balances[addr <- v] } *)
+
+  end
+end

--- a/examples/dexter2/liquidity.tzw
+++ b/examples/dexter2/liquidity.tzw
@@ -103,8 +103,8 @@ scope Cpmm
     s'.lqt_address = s.lqt_address /\
     let lqt_minted = s'.lqt_total - s.lqt_total in
     match op with
-    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ _ ICon.Contract.Transfer)
-            (Cons (Xfer (ICon.Gp ((q, _) : (int, address))) _ lqc ICon.Contract.MintOrBurn)
+    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ { ct_ep=ICon.Contract.Transfer; ct_addr=_ })
+            (Cons (Xfer (ICon.Gp ((q, _) : (int, address))) _ { ct_ep=ICon.Contract.MintOrBurn; ct_addr=lqc })
 	     Nil) ->
       q = lqt_minted /\
       lqc = s.lqt_address
@@ -118,9 +118,9 @@ scope Cpmm
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total - lqt_burned /\
     match op with
-    | Cons (Xfer (ICon.Gp ( (q, _) : (int, address) )) _ lqc ICon.Contract.MintOrBurn)
-      (Cons (Xfer (ICon.Gp ( _ : list (address, list (address, (nat, nat))))) _ _ ICon.Contract.Transfer)
-      (Cons (Xfer (ICon.Gp ( _ : unit)) _ _ ICon.Contract.Default)
+    | Cons (Xfer (ICon.Gp ( (q, _) : (int, address) )) _ { ct_ep=ICon.Contract.MintOrBurn; ct_addr=lqc })
+      (Cons (Xfer (ICon.Gp ( _ : list (address, list (address, (nat, nat))))) _ { ct_ep=ICon.Contract.Transfer; ct_addr=_ })
+      (Cons (Xfer (ICon.Gp ( _ : unit)) _ { ct_ep=ICon.Contract.Default; ct_addr=_ })
        Nil)) ->
       q = 0 - lqt_burned /\
       lqc = s.lqt_address
@@ -131,7 +131,7 @@ scope Cpmm
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-     | Cons (Xfer (ICon.Gp (_ : list (address, list (address, (nat, nat))))) _ _ ICon.Contract.Transfer) Nil ->
+     | Cons (Xfer (ICon.Gp (_ : list (address, list (address, (nat, nat))))) _ { ct_ep=ICon.Contract.Transfer; ct_addr=_ }) Nil ->
       True
     | _ -> False
     end
@@ -140,8 +140,8 @@ scope Cpmm
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ _ ICon.Contract.Transfer)
-            (Cons (Xfer (ICon.Gp (_ : unit)) _ _ ICon.Contract.Default)
+    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ { ct_ep=ICon.Contract.Transfer; ct_addr=_ })
+            (Cons (Xfer (ICon.Gp (_ : unit)) _ { ct_ep=ICon.Contract.Default; ct_addr=_ })
                    Nil) ->
       True
     | _ -> False
@@ -151,8 +151,8 @@ scope Cpmm
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ _ ICon.Contract.Transfer)
-           (Cons (Xfer (ICon.Gp (_ : (address, nat, timestamp))) _ _ ICon.Contract.Xtz_to_token)
+    | Cons (Xfer (ICon.Gp (_ : list (address, (list (address, (nat, nat)))))) _ { ct_ep=ICon.Contract.Transfer; ct_addr=_ })
+           (Cons (Xfer (ICon.Gp (_ : (address, nat, timestamp))) _ { ct_ep=ICon.Contract.Xtz_to_token; ct_addr=_ })
 	    Nil) ->
       True
     | _ -> False
@@ -182,7 +182,7 @@ scope Cpmm
     s'.lqt_address = s.lqt_address /\
     s'.lqt_total = s.lqt_total /\
     match op with
-    | Cons (Xfer (ICon.Gp (_ : unit)) _ _ ICon.Contract.Update_token_pool) Nil ->
+    | Cons (Xfer (ICon.Gp (_ : unit)) _ { ct_ep=ICon.Contract.Update_token_pool; ct_addr=_ }) Nil ->
       True
     | _ -> False
     end
@@ -258,39 +258,39 @@ scope Lqt
     let maybe_new_balance = if new_balance = 0 then None else Some new_balance in
     s'.tokens = s.tokens[target <- maybe_new_balance]
 
-  predicate getAllowance (_st : step) (p : ((address, address), contract nat)) (s : storage) (op : list operation) (s' : storage) =
+  predicate getAllowance (_st : step) (p : ((address, address), contract)) (s : storage) (op : list operation) (s' : storage) =
     let (_p1, p2) = p in
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
     match op with
-    | Cons (Xfer _ _ c ICon.Contract.Default) Nil ->
-      c = callback
+    | Cons (Xfer _ _ c) Nil ->
+      c = callback /\ c.ct_ep = ICon.Contract.Default
     | _ -> False
     end
 
-  predicate getBalance (_st : step) (p : (address, contract nat)) (s : storage) (op : list operation) (s' : storage) =
+  predicate getBalance (_st : step) (p : (address, contract)) (s : storage) (op : list operation) (s' : storage) =
     let (_p1, p2) = p in
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
     match op with
-    | Cons (Xfer _ _ c ICon.Contract.Default) Nil ->
-      c = callback
+    | Cons (Xfer _ _ c) Nil ->
+      c = callback /\ c.ct_ep = ICon.Contract.Default
     | _ -> False
     end
 
-  predicate getTotalSupply (_st : step) (p : (unit, contract nat)) (s : storage) (op : list operation) (s' : storage) =
+  predicate getTotalSupply (_st : step) (p : (unit, contract)) (s : storage) (op : list operation) (s' : storage) =
     let (_p1, p2) = p in
     let callback = p2 in
     s'.total_supply = s.total_supply /\
     s'.admin = s.admin /\
     s'.tokens = s.tokens /\
     match op with
-    | Cons (Xfer _ _ c ICon.Contract.Default) Nil ->
-      c = callback
+    | Cons (Xfer _ _ c) Nil ->
+      c = callback /\ c.ct_ep = ICon.Contract.Default
     | _ -> False
     end
 

--- a/examples/mixer.tzw
+++ b/examples/mixer.tzw
@@ -88,10 +88,10 @@ scope Mixer
           if sha256 (concat key passcode) = hash
           then
             s' = { s with balances = b[key <- None] } /\
-            ops = Cons (Xfer (ICon.Gp (() : unit)) token st.sender ICon.Contract.Default) Nil
+            ops = Cons (Xfer (ICon.Gp (() : unit)) token (ICon.Contract st.sender)) Nil
           else
             s' = s /\
-            ops = ops = Cons (Xfer (ICon.Gp (() : unit)) 0 st.sender ICon.Contract.Default) Nil
+            ops = ops = Cons (Xfer (ICon.Gp (() : unit)) 0 (ICon.Contract st.sender)) Nil
       end
   end
 
@@ -122,7 +122,7 @@ scope Splitter
   scope Spec
     predicate split (st : step) (p : (bytes, bytes, list address)) (s : storage) (ops : list operation) (s' : storage) =
       let key, passcode, dests = p in
-      ops = Cons (Xfer (ICon.Gp ((key, passcode) : (bytes, bytes))) 0 s.mixer_addr ICon.Contract.Withdraw) Nil /\
+      ops = Cons (Xfer (ICon.Gp ((key, passcode) : (bytes, bytes))) 0 (ICon.Contract.Withdraw s.mixer_addr)) Nil /\
       s'.state = Some dests /\
       s.mixer_addr = s'.mixer_addr
     
@@ -134,7 +134,7 @@ scope Splitter
           s' = s
       | Some dests ->
           let d = div st.amount (length dests) in
-          let c_op addr = Xfer (ICon.Gp (() : unit)) d addr ICon.Contract.Default in
+          let c_op addr = Xfer (ICon.Gp (() : unit)) d (ICon.Contract addr) in
           (* ops = map c_op dests /\ *)
           ops = (* Extract 3 times *)
             match dests with

--- a/examples/mixer_with_implicit.tzw
+++ b/examples/mixer_with_implicit.tzw
@@ -114,14 +114,14 @@ scope Mixer
     predicate withdraw (st : step) (p : (bytes, bytes)) (s : storage) (ops : list operation) (s' : storage) =
       let (key, passcode) = p in
       let b = s.balances in
-      let xfer_nothing = s' = s /\ ops = Cons (Xfer (ICon.Gp (() : unit)) 0 st.sender ICon.Contract.Default) Nil in
+      let xfer_nothing = s' = s /\ ops = Cons (Xfer (ICon.Gp (() : unit)) 0 (ICon.Contract st.sender)) Nil in
       match b[key] with
       | None -> xfer_nothing
       | Some (hash, token) ->
           if sha256 (concat key passcode) = hash
           then
             s' = { s with balances = b[key <- None] } /\
-            ops = Cons (Xfer (ICon.Gp (() : unit)) token st.sender ICon.Contract.Default) Nil
+            ops = Cons (Xfer (ICon.Gp (() : unit)) token (ICon.Contract st.sender)) Nil
           else
             xfer_nothing
       end
@@ -167,7 +167,7 @@ scope Splitter
   scope Spec
     predicate split (st : step) (p : (bytes, bytes, list address)) (s : storage) (ops : list operation) (s' : storage) =
       let (key, passcode, dests) = p in
-      ops = Cons (Xfer (ICon.Gp ((key, passcode) : (bytes, bytes))) 0 s.mixer_addr ICon.Contract.Withdraw) Nil /\
+      ops = Cons (Xfer (ICon.Gp ((key, passcode) : (bytes, bytes))) 0 (ICon.Contract.Withdraw s.mixer_addr)) Nil /\
       s'.state = Some dests /\
       s.mixer_addr = s'.mixer_addr
 
@@ -183,14 +183,14 @@ scope Splitter
             match dests with
             | Nil -> Nil
             | Cons addr0 t ->
-                Cons (Xfer (ICon.Gp (() : unit)) d addr0 ICon.Contract.Default)
+                Cons (Xfer (ICon.Gp (() : unit)) d (ICon.Contract addr0))
                   (match dests with
                   | Nil -> Nil
                   | Cons addr1 t ->
-                      Cons (Xfer (ICon.Gp (() : unit)) d addr1 ICon.Contract.Default)
+                      Cons (Xfer (ICon.Gp (() : unit)) d (ICon.Contract addr1))
                         (match dests with
                         | Nil -> Nil
-                        | Cons addr2 _ -> Cons (Xfer (ICon.Gp (() : unit)) d addr2 ICon.Contract.Default) Nil
+                        | Cons addr2 _ -> Cons (Xfer (ICon.Gp (() : unit)) d (ICon.Contract addr2)) Nil
                         end)
                   end)
             end /\
@@ -229,7 +229,7 @@ scope Implicit0
   scope Spec
     predicate send (st : step) (p : (bytes, bytes)) (s : storage) (ops : list operation) (s' : storage) =
       let (key, passcode) = p in
-      ops = Cons (Xfer (ICon.Gp ((key, passcode, (Cons st.self Nil)) : (bytes, bytes, list address))) 0 Splitter.addr ICon.Contract.Split) Nil
+      ops = Cons (Xfer (ICon.Gp ((key, passcode, (Cons st.self Nil)) : (bytes, bytes, list address))) 0 (ICon.Contract.Split Splitter.addr)) Nil
     
     predicate default (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
       ops = Nil

--- a/examples/test_defs_in_preambles.tzw
+++ b/examples/test_defs_in_preambles.tzw
@@ -9,8 +9,8 @@ scope Preambles
     (s : a_storage)
     (ops : list operation)
     (v : nat) : list operation =
-    let ops = Cons (Xfer (ICon.Gp (v : nat)) 0 s.self_address ICon.Contract.Add) ops in
-    let ops = Cons (Xfer (ICon.Gp (v : nat)) 0 s.self_address ICon.Contract.Add) ops in
+    let ops = Cons (Xfer (ICon.Gp (v : nat)) 0 (ICon.Contract.add s.self_address)) ops in
+    let ops = Cons (Xfer (ICon.Gp (v : nat)) 0 (ICon.Contract.add s.self_address)) ops in
     ops
 
 end

--- a/examples/token_swap.tzw
+++ b/examples/token_swap.tzw
@@ -89,8 +89,8 @@ scope Swap
       let (a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) = p in
       a_addr <> self st /\
       b_addr <> self st /\
-      let op0 = Xfer (ICon.Gp ((a_addr, b_addr, a_token_id, a_amount) : (address, address, nat, nat))) 0 Token0.addr ICon.Contract.Transfer in
-      let op1 = Xfer (ICon.Gp ((b_addr, a_addr, b_token_id, b_amount) : (address, address, nat, nat))) 0 Token1.addr ICon.Contract.Transfer in
+      let op0 = Xfer (ICon.Gp ((a_addr, b_addr, a_token_id, a_amount) : (address, address, nat, nat))) 0 (ICon.Contract.Transfer Token0.addr) in
+      let op1 = Xfer (ICon.Gp ((b_addr, a_addr, b_token_id, b_amount) : (address, address, nat, nat))) 0 (ICon.Contract.Transfer Token1.addr) in
       ops = Cons op0 (Cons op1 Nil)
 
   end

--- a/examples/token_swap_with_implicit.tzw
+++ b/examples/token_swap_with_implicit.tzw
@@ -89,8 +89,8 @@ scope Swap
       let (a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) = p in
       a_addr <> self st /\
       b_addr <> self st /\
-      let op0 = Xfer (ICon.Gp ((a_addr, b_addr, a_token_id, a_amount) : (address, address, nat, nat))) 0 Token0.addr ICon.Contract.Transfer in
-      let op1 = Xfer (ICon.Gp ((b_addr, a_addr, b_token_id, b_amount) : (address, address, nat, nat))) 0 Token1.addr ICon.Contract.Transfer in
+      let op0 = Xfer (ICon.Gp ((a_addr, b_addr, a_token_id, a_amount) : (address, address, nat, nat))) 0 (ICon.Contract.Transfer Token0.addr) in
+      let op1 = Xfer (ICon.Gp ((b_addr, a_addr, b_token_id, b_amount) : (address, address, nat, nat))) 0 (ICon.Contract.Transfer Token1.addr) in
       ops = Cons op0 (Cons op1 Nil)
 
   end
@@ -261,9 +261,9 @@ scope Implicit0
       (ops : list operation)
       (s' : storage) =
       let (a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) = p in
-      let op0 = Xfer (ICon.Gp ((Left (self st, (Swap.addr, a_token_id))) : (or (address, (address, nat)) (address, (address, nat))))) 0 Token0.addr ICon.Contract.Update_operators in
-      let op1 = Xfer (ICon.Gp (((self st), a_token_id, a_amount, b_addr, b_token_id, b_amount) : (address, nat, nat, address, nat, nat))) 0 Swap.addr ICon.Contract.Swap in
-      let op2 = Xfer (ICon.Gp ((Right (self st, (Swap.addr, a_token_id))) : (or (address, (address, nat)) (address, (address, nat))))) 0 Token0.addr ICon.Contract.Update_operators in
+      let op0 = Xfer (ICon.Gp ((Left (self st, (Swap.addr, a_token_id))) : (or (address, (address, nat)) (address, (address, nat))))) 0 (ICon.Contract.Update_operators Token0.addr) in
+      let op1 = Xfer (ICon.Gp (((self st), a_token_id, a_amount, b_addr, b_token_id, b_amount) : (address, nat, nat, address, nat, nat))) 0 (ICon.Contract.Swap Swap.addr) in
+      let op2 = Xfer (ICon.Gp ((Right (self st, (Swap.addr, a_token_id))) : (or (address, (address, nat)) (address, (address, nat))))) 0 (ICon.Contract.Update_operators Token0.addr) in
       ops = Cons op0 (Cons op1 (Cons op2 Nil))
   end
 end

--- a/lib/gen_mlw.ml
+++ b/lib/gen_mlw.ml
@@ -1356,8 +1356,13 @@ let convert_mlw (tzw : Tzw.t) =
         (* contents of `mlw/step.mlw` *)
         step;
         [
-          Dtype [ (* type gparam = .. *) gen_gparam epp ];
-          Dtype [ (* type operation = .. *) G.operation_ty_def ];
+          Dtype
+            [
+              (* type gparam = .. *)
+              gen_gparam epp;
+              (* type operation = .. *)
+              G.operation_ty_def;
+            ];
         ];
         (* contents of [scope Preambles] *)
         preambles;

--- a/lib/gen_mlw.ml
+++ b/lib/gen_mlw.ml
@@ -43,8 +43,10 @@ let storage_ty_ident = ident "storage"
 let storage_wf_ident = ident "is_storage_wf"
 let gparam_ty_ident = ident "gparam"
 let operation_ty_ident = ident "operation"
+let operation_wf_ident = ident "is_operation_wf"
 let entrypoint_ty_ident = ident "entrypoint"
 let contract_ty_ident = ident "contract"
+let contract_wf_ident = ident "is_contract_wf"
 let gas_ident = ident "g"
 let terminate_ident = ident "Terminate"
 let insufficient_mutez_ident = ident "Insufficient_mutez"
@@ -423,6 +425,7 @@ module Generator (D : Desc) = struct
         PTtyapp (qid entrypoint_ty_ident, []) )
 
   let contract_pty = PTtyapp (qid contract_ty_ident, [])
+  let operation_pty = PTtyapp (qid operation_ty_ident, [])
   let storage_pty_of c = PTtyapp (qid_of c storage_ty_ident, [])
   let qid_param_wf_of (c : contract) : qualid = qid_of c param_wf_ident
   let qid_storage_wf_of (c : contract) : qualid = qid_of c storage_wf_ident
@@ -1423,7 +1426,21 @@ let convert_mlw (tzw : Tzw.t) =
               ] );
         ];
         (* contents of `mlw/step.mlw` *)
-        [ (* type contract = .. *) Dtype [ contract_ty_def ] ];
+        [
+          (* type contract = .. *)
+          Dtype [ contract_ty_def ];
+          (* predicate is_contract_wf (cont : contract) = .. *)
+          Dlogic
+            [
+              {
+                ld_loc = Loc.dummy_position;
+                ld_ident = contract_wf_ident;
+                ld_params = [ mk_param "_cont" G.contract_pty ];
+                ld_type = None;
+                ld_def = Some (term Ttrue);
+              };
+            ];
+        ];
         step;
         [
           Dtype
@@ -1432,6 +1449,16 @@ let convert_mlw (tzw : Tzw.t) =
               gen_gparam epp;
               (* type operation = .. *)
               G.operation_ty_def;
+            ];
+          Dlogic
+            [
+              {
+                ld_loc = Loc.dummy_position;
+                ld_ident = operation_wf_ident;
+                ld_params = [ mk_param "_op" G.operation_pty ];
+                ld_type = None;
+                ld_def = Some (term Ttrue);
+              };
             ];
         ];
         (* contents of [scope Preambles] *)

--- a/lib/mlw/headers.mlw
+++ b/lib/mlw/headers.mlw
@@ -86,10 +86,6 @@ type timestamp = int
 
 predicate is_timestamp_wf (_ : address) = true
 
-type contract 'a = int
-
-predicate is_contract_wf (_ : 'a -> bool) (_ : contract 'a) = true
-
 type or 'a 'b = Left 'a | Right 'b
 
 predicate is_or_wf (is_a_wf : 'a -> bool) (is_b_wf : 'b -> bool) (ab : or 'a 'b) =

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -21,7 +21,7 @@ type t =
   | S_timestamp
   | S_mutez
   | S_address
-  | S_contract of t
+  | S_contract
   | S_operation
   | S_key
   | S_key_hash
@@ -66,7 +66,7 @@ let rec pp_sort fmt (ty : t) =
   | S_timestamp -> fprintf fmt "timestamp"
   | S_mutez -> fprintf fmt "mutez"
   | S_address -> fprintf fmt "address"
-  | S_contract ty -> fprintf fmt "(@[contract@ %a@])" pp_sort ty
+  | S_contract -> fprintf fmt "contract"
   | S_operation -> fprintf fmt "operation"
   | S_key -> fprintf fmt "key"
   | S_key_hash -> fprintf fmt "key_hash"
@@ -144,9 +144,7 @@ let rec sort_of_pty (pty : pty) : t iresult =
       | "lambda" ->
           let* s1, s2 = elt2 pl in
           return @@ S_lambda (s1, s2)
-      | "contract" ->
-          let* s = elt1 pl in
-          return @@ S_contract s
+      | "contract" -> return S_contract
       | s -> error_with "unknown sort %s" s)
   | PTtuple [] -> return @@ S_unit
   | PTtuple [ pty ] -> sort_of_pty pty
@@ -184,7 +182,7 @@ let rec pty_of_sort (s : t) : Ptree.pty =
   | S_timestamp -> ty "timestamp"
   | S_mutez -> ty "mutez"
   | S_address -> ty "address"
-  | S_contract s -> PTtyapp (qualid [ "contract" ], [ pty_of_sort s ])
+  | S_contract -> ty "contract"
   | S_operation -> ty "operation"
   | S_key -> ty "key"
   | S_key_hash -> ty "key_hash"

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -21,7 +21,9 @@ type t =
   | S_timestamp
   | S_mutez
   | S_address
-  | S_contract of t
+  | S_contract
+    (* Original Michelson receives 1 type argument.
+       The difference is for the way of transforming code *)
   | S_operation
   | S_key
   | S_key_hash


### PR DESCRIPTION
Try to implement the contract part of https://github.com/westpaddy/icon-why3/blob/nishida/contract-ty/req/gparam.md

- the entrypoint type definition follows the implementation by Jun
- the contract type definition follows that specification above
  - s.t. `type contract = { ct_ep : entrypoint; ct_addr : address }`
- `Xfer` receives 3 parameters: `gparam`, `mutez`, and `contract`
  - Reverted 4 to 3. `entrypoint` and `address` are merged into `contract` (because it seems to have no problem)
- `ICon.Contract addr` is converted to `{ ct_ep=(Default : ICon.Contract.entrypoint); ct_addr=addr }`
- `ICon.Contract.ep addr` is converted to `{ ct_ep=(Ep : ICon.Contract.entrypoint); ct_addr=addr) }`

and some fixes (I commented in #30) and `dao.tzw` example that includes an entrypoint receiving a `contact` parameter.