### PR TITLE
Update examples : mixer, token_swap

### DIFF
--- a/examples/mixer.tzw
+++ b/examples/mixer.tzw
@@ -60,8 +60,8 @@ scope Mixer
 
   predicate pre (st : step) (gp : gparam) (c : ctx) =
     storage_inv c /\
-    match gp with
-    | Gp'Mixer'withdraw key passcode ->
+    match st.entrypoint with
+    | ICon.Contract.Withdraw ->
         (st.sender <> Splitter.addr -> splitter_storage_inv c)
     | _ -> splitter_storage_inv c
     end
@@ -73,12 +73,14 @@ scope Mixer
   let upper_ops = 1
 
   scope Spec
-    predicate deposit (st : step) (key : bytes) (hash : bytes) (s : storage) (ops : list operation) (s' : storage) =
+    predicate deposit (st : step) (p : (bytes, bytes)) (s : storage) (ops : list operation) (s' : storage) =
+      let key, hash = p in
       let b = s.balances[key <- Some (hash, st.amount)] in
       s' = { s with balances = b } /\
       ops = Nil
 
-    predicate withdraw (st : step) (key : bytes) (passcode : bytes) (s : storage) (ops : list operation) (s' : storage) =
+    predicate withdraw (st : step) (p : (bytes, bytes)) (s : storage) (ops : list operation) (s' : storage) =
+      let key, passcode = p in
       let b = s.balances in
       match b[key] with
       | None -> false
@@ -86,10 +88,10 @@ scope Mixer
           if sha256 (concat key passcode) = hash
           then
             s' = { s with balances = b[key <- None] } /\
-            ops = Cons (Xfer (Gp'Unknown'default ()) token st.sender) Nil
+            ops = Cons (Xfer (ICon.Gp (() : unit)) token st.sender ICon.Contract.Default) Nil
           else
             s' = s /\
-            ops = ops = Cons (Xfer (Gp'Unknown'default ()) 0 st.sender) Nil
+            ops = ops = Cons (Xfer (ICon.Gp (() : unit)) 0 st.sender ICon.Contract.Default) Nil
       end
   end
 
@@ -103,10 +105,10 @@ scope Splitter
 
   predicate pre (st : step) (gp : gparam) (c : ctx) =
     storage_inv c /\
-    match gp with
-    | Gp'Splitter'split key passcode dests ->
+    match st.entrypoint with
+    | ICon.Contract.Split ->
         splitter_storage_inv c
-    | Gp'Splitter'default () ->
+    | ICon.Contract.Default ->
         st.sender <> Mixer.addr -> splitter_storage_inv c
     | _ -> false
     end
@@ -118,8 +120,9 @@ scope Splitter
   let upper_ops = 3
 
   scope Spec
-    predicate split (st : step) (key : bytes) (passcode : bytes) (dests : list address) (s : storage) (ops : list operation) (s' : storage) =
-      ops = Cons (Xfer (Gp'Mixer'withdraw key passcode) 0 s.mixer_addr) Nil /\
+    predicate split (st : step) (p : (bytes, bytes, list address)) (s : storage) (ops : list operation) (s' : storage) =
+      let key, passcode, dests = p in
+      ops = Cons (Xfer (ICon.Gp ((key, passcode) : (bytes, bytes))) 0 s.mixer_addr ICon.Contract.Withdraw) Nil /\
       s'.state = Some dests /\
       s.mixer_addr = s'.mixer_addr
     
@@ -131,7 +134,7 @@ scope Splitter
           s' = s
       | Some dests ->
           let d = div st.amount (length dests) in
-          let c_op addr = Xfer (Gp'Unknown'default ()) d addr in
+          let c_op addr = Xfer (ICon.Gp (() : unit)) d addr ICon.Contract.Default in
           (* ops = map c_op dests /\ *)
           ops = (* Extract 3 times *)
             match dests with

--- a/examples/mixer_with_implicit.tzw
+++ b/examples/mixer_with_implicit.tzw
@@ -73,29 +73,30 @@ scope Mixer
 
   predicate pre (st : step) (gp : gparam) (c : ctx) =
     storage_inv c /\
-    match gp with
-    | Gp'Mixer'withdraw key passcode ->
+    match st.entrypoint with
+    | ICon.Contract.Withdraw ->
         (st.sender <> Splitter.addr -> splitter_storage_inv c) /\
         (st.sender = Splitter.addr -> st.amount = 0)
-    | Gp'Mixer'deposit _ _ -> splitter_storage_inv c
+    | ICon.Contract.Deposit -> splitter_storage_inv c
     | _ -> false
     end
 
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     storage_inv c' /\
     splitter_storage_inv c' /\
-    match gp with
-    | Gp'Mixer'withdraw key passcode ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Withdraw, ICon.Gp ((key, passcode) : (bytes, bytes)) ->
         c.splitter_storage.Splitter.state = Some (Cons Implicit0.addr Nil) ->
         mixer_balance_cond key passcode c c'
-    | Gp'Mixer'deposit _ _ -> true
+    | ICon.Contract.Deposit, _ -> true
     | _ -> false
     end
 
   let upper_ops = 1
 
   scope Spec
-    predicate deposit (st : step) (key : bytes) (hash : bytes) (s : storage) (ops : list operation) (s' : storage) =
+    predicate deposit (st : step) (p : (bytes, bytes)) (s : storage) (ops : list operation) (s' : storage) =
+      let (key, hash) = p in
       match s.balances[key] with
       | None ->
           let b = s.balances[key <- Some (hash, st.amount)] in
@@ -110,16 +111,17 @@ scope Mixer
       end /\
       ops = Nil
 
-    predicate withdraw (st : step) (key : bytes) (passcode : bytes) (s : storage) (ops : list operation) (s' : storage) =
+    predicate withdraw (st : step) (p : (bytes, bytes)) (s : storage) (ops : list operation) (s' : storage) =
+      let (key, passcode) = p in
       let b = s.balances in
-      let xfer_nothing = s' = s /\ ops = Cons (Xfer (Gp'Unknown'default ()) 0 st.sender) Nil in
+      let xfer_nothing = s' = s /\ ops = Cons (Xfer (ICon.Gp (() : unit)) 0 st.sender ICon.Contract.Default) Nil in
       match b[key] with
       | None -> xfer_nothing
       | Some (hash, token) ->
           if sha256 (concat key passcode) = hash
           then
             s' = { s with balances = b[key <- None] } /\
-            ops = Cons (Xfer (Gp'Unknown'default ()) token st.sender) Nil
+            ops = Cons (Xfer (ICon.Gp (() : unit)) token st.sender ICon.Contract.Default) Nil
           else
             xfer_nothing
       end
@@ -136,11 +138,11 @@ scope Splitter
 
   predicate pre (st : step) (gp : gparam) (c : ctx) =
     storage_inv c /\
-    match gp with
-    | Gp'Splitter'split key passcode dests ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Split, ICon.Gp ((key, passcode, dests) : (bytes, bytes, list address)) ->
         splitter_storage_inv c /\
         (st.sender = Implicit0.addr -> dests = Cons Implicit0.addr Nil)
-    | Gp'Splitter'default () ->
+    | ICon.Contract.Default, _ ->
         st.sender <> Mixer.addr -> splitter_storage_inv c
     | _ -> false
     end
@@ -148,11 +150,11 @@ scope Splitter
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     storage_inv c' /\
     splitter_storage_inv c' /\
-    match gp with
-    | Gp'Splitter'split key passcode dests ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Split, ICon.Gp ((key, passcode, dests) : (bytes, bytes, list address)) ->
         st.sender = Implicit0.addr ->
         mixer_balance_cond key passcode c c'
-    | Gp'Splitter'default () ->
+    | ICon.Contract.Default, ICon.Gp (() : unit) ->
         (c.splitter_storage.Splitter.state = Some (Cons Implicit0.addr Nil) \/
          c.splitter_storage.Splitter.state = None) ->
         (c.mixer_balance = c'.mixer_balance /\
@@ -163,8 +165,9 @@ scope Splitter
   let upper_ops = 3
 
   scope Spec
-    predicate split (st : step) (key : bytes) (passcode : bytes) (dests : list address) (s : storage) (ops : list operation) (s' : storage) =
-      ops = Cons (Xfer (Gp'Mixer'withdraw key passcode) 0 s.mixer_addr) Nil /\
+    predicate split (st : step) (p : (bytes, bytes, list address)) (s : storage) (ops : list operation) (s' : storage) =
+      let (key, passcode, dests) = p in
+      ops = Cons (Xfer (ICon.Gp ((key, passcode) : (bytes, bytes))) 0 s.mixer_addr ICon.Contract.Withdraw) Nil /\
       s'.state = Some dests /\
       s.mixer_addr = s'.mixer_addr
 
@@ -180,14 +183,14 @@ scope Splitter
             match dests with
             | Nil -> Nil
             | Cons addr0 t ->
-                Cons (Xfer (Gp'Unknown'default ()) d addr0)
+                Cons (Xfer (ICon.Gp (() : unit)) d addr0 ICon.Contract.Default)
                   (match dests with
                   | Nil -> Nil
                   | Cons addr1 t ->
-                      Cons (Xfer (Gp'Unknown'default ()) d addr1)
+                      Cons (Xfer (ICon.Gp (() : unit)) d addr1 ICon.Contract.Default)
                         (match dests with
                         | Nil -> Nil
-                        | Cons addr2 _ -> Cons (Xfer (Gp'Unknown'default ()) d addr2) Nil
+                        | Cons addr2 _ -> Cons (Xfer (ICon.Gp (() : unit)) d addr2 ICon.Contract.Default) Nil
                         end)
                   end)
             end /\
@@ -201,19 +204,19 @@ scope Implicit0
   predicate pre (st : step) (gp : gparam) (c : ctx) =
     storage_inv c /\
     splitter_storage_inv c /\
-    match gp with
-    | Gp'Implicit0'send _ _
-    | Gp'Implicit0'default () -> true
+    match st.entrypoint with
+    | ICon.Contract.Send
+    | ICon.Contract.Default -> true
     | _ -> false
     end
 
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     storage_inv c' /\
     splitter_storage_inv c' /\
-    match gp with
-    | Gp'Implicit0'send key passcode ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Send, ICon.Gp ((key, passcode) : (bytes, bytes)) ->
         mixer_balance_cond key passcode c c'
-    | Gp'Implicit0'default () ->
+    | ICon.Contract.Default, ICon.Gp (() : unit) ->
         c.mixer_balance = c'.mixer_balance /\
         c.mixer_storage = c'.mixer_storage
     | _ -> false
@@ -224,8 +227,9 @@ scope Implicit0
   let upper_ops = 1
 
   scope Spec
-    predicate send (st : step) (key : bytes) (passcode : bytes) (s : storage) (ops : list operation) (s' : storage) =
-      ops = Cons (Xfer (Gp'Splitter'split key passcode (Cons st.self Nil)) 0 Splitter.addr) Nil
+    predicate send (st : step) (p : (bytes, bytes)) (s : storage) (ops : list operation) (s' : storage) =
+      let (key, passcode) = p in
+      ops = Cons (Xfer (ICon.Gp ((key, passcode, (Cons st.self Nil)) : (bytes, bytes, list address))) 0 Splitter.addr ICon.Contract.Split) Nil
     
     predicate default (st : step) (_p : unit) (s : storage) (ops : list operation) (s' : storage) =
       ops = Nil

--- a/examples/token_swap.tzw
+++ b/examples/token_swap.tzw
@@ -58,10 +58,10 @@ scope Swap
 
   predicate pre (st : step) (gp : gparam) (c : ctx) = Token0.addr <> Token1.addr
 
-  predicate post (_st : step) (gp : gparam) (c : ctx) (c' : ctx) =
+  predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     balances_invariant c c' /\
-    match gp with
-    | Gp'Swap'swap a_addr a_token_id a_amount b_addr b_token_id b_amount ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Swap, ICon.Gp ((a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) : (address, nat, nat, address, nat, nat)) ->
         c.token0_storage.Token0.operators[a_token_id][a_addr][Swap.addr] /\
         c.token1_storage.Token1.operators[b_token_id][b_addr][Swap.addr] /\
         ( let balances = c.token0_storage.Token0.balances in
@@ -82,19 +82,15 @@ scope Swap
   scope Spec
     predicate swap
       (st : step)
-      (a_addr : address)
-      (a_token_id : nat)
-      (a_amount : nat)
-      (b_addr : address)
-      (b_token_id : nat)
-      (b_amount : nat)
+      (p : (address, nat, nat, address, nat, nat))
       (s : storage)
       (ops : list operation)
       (s' : storage) =
+      let (a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) = p in
       a_addr <> self st /\
       b_addr <> self st /\
-      let op0 = Xfer (Gp'Token0'transfer a_addr b_addr a_token_id a_amount) 0 Token0.addr in
-      let op1 = Xfer (Gp'Token1'transfer b_addr a_addr b_token_id b_amount) 0 Token1.addr in
+      let op0 = Xfer (ICon.Gp ((a_addr, b_addr, a_token_id, a_amount) : (address, address, nat, nat))) 0 Token0.addr ICon.Contract.Transfer in
+      let op1 = Xfer (ICon.Gp ((b_addr, a_addr, b_token_id, b_amount) : (address, address, nat, nat))) 0 Token1.addr ICon.Contract.Transfer in
       ops = Cons op0 (Cons op1 Nil)
 
   end
@@ -112,15 +108,15 @@ scope Token0
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     balances_invariant c c' /\
     c.token1_storage = c'.token1_storage /\
-    match gp with
-    | Gp'Token0'transfer from_ to_ token_id amount ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Transfer, ICon.Gp ((from_, to_, token_id, amount) : (address, address, nat, nat)) ->
         ( from_ = sender st \/ c.token0_storage.Token0.operators[token_id][from_][sender st]) /\
           let balances = c.token0_storage.Token0.balances in
           let balances' = c'.token0_storage.Token0.balances in
           let b, b' = update_balance from_ to_ token_id amount balances balances' in
           b = b' /\
           c.token0_storage.Token0.operators = c'.token0_storage.Token0.operators
-    | Gp'Token0'update_operators _ ->
+    | ICon.Contract.Update_operators, _ ->
         c.token0_storage.Token0.balances = c'.token0_storage.Token0.balances
     | _ -> false
     end
@@ -131,13 +127,11 @@ scope Token0
 
     predicate transfer
       (st : step)
-      (from_ : address)
-      (to_ : address)
-      (token_id : nat)
-      (amount : nat)
+      (p : (address, address, nat, nat))
       (s : storage)
       (ops : list operation)
       (s' : storage) =
+        let (from_, to_, token_id, amount) = p in
         let sender = sender st in
         (from_ = sender \/ s.operators[token_id][from_][sender]) /\
         s.balances[token_id][from_] >= amount /\
@@ -179,15 +173,15 @@ scope Token1
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     balances_invariant c c' /\
     c.token0_storage = c'.token0_storage /\
-    match gp with
-    | Gp'Token1'transfer from_ to_ token_id amount ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Transfer, ICon.Gp ((from_, to_, token_id, amount): (address, address, nat, nat)) ->
         ( from_ = sender st \/ c.token1_storage.Token1.operators[token_id][from_][sender st]) /\
           let balances = c.token1_storage.Token1.balances in
           let balances' = c'.token1_storage.Token1.balances in
           let b, b' = update_balance from_ to_ token_id amount balances balances' in
           b = b' /\
           c.token1_storage.Token1.operators = c'.token1_storage.Token1.operators
-    | Gp'Token1'update_operators _ ->
+    | ICon.Contract.Update_operators, _ ->
         c.token1_storage.Token1.balances = c'.token1_storage.Token1.balances
     | _ -> false
     end
@@ -198,13 +192,11 @@ scope Token1
 
     predicate transfer
       (st : step)
-      (from_ : address)
-      (to_ : address)
-      (token_id : nat)
-      (amount : nat)
+      (p : (address, address, nat, nat))
       (s : storage)
       (ops : list operation)
       (s' : storage) =
+        let (from_, to_, token_id, amount)= p in
         let sender = sender st in
         (from_ = sender \/ s.operators[token_id][from_][sender]) /\
         s.balances[token_id][from_] >= amount /\

--- a/examples/token_swap_with_implicit.tzw
+++ b/examples/token_swap_with_implicit.tzw
@@ -58,10 +58,10 @@ scope Swap
 
   predicate pre (st : step) (gp : gparam) (c : ctx) = Token0.addr <> Token1.addr
 
-  predicate post (_st : step) (gp : gparam) (c : ctx) (c' : ctx) =
+  predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     balances_invariant c c' /\
-    match gp with
-    | Gp'Swap'swap a_addr a_token_id a_amount b_addr b_token_id b_amount ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Swap, ICon.Gp ((a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) : (address, nat, nat, address, nat, nat)) ->
         c.token0_storage.Token0.operators[a_token_id][a_addr][Swap.addr] /\
         c.token1_storage.Token1.operators[b_token_id][b_addr][Swap.addr] /\
         ( let balances = c.token0_storage.Token0.balances in
@@ -82,19 +82,15 @@ scope Swap
   scope Spec
     predicate swap
       (st : step)
-      (a_addr : address)
-      (a_token_id : nat)
-      (a_amount : nat)
-      (b_addr : address)
-      (b_token_id : nat)
-      (b_amount : nat)
+      (p : (address, nat, nat, address, nat, nat))
       (s : storage)
       (ops : list operation)
       (s' : storage) =
+      let (a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) = p in
       a_addr <> self st /\
       b_addr <> self st /\
-      let op0 = Xfer (Gp'Token0'transfer a_addr b_addr a_token_id a_amount) 0 Token0.addr in
-      let op1 = Xfer (Gp'Token1'transfer b_addr a_addr b_token_id b_amount) 0 Token1.addr in
+      let op0 = Xfer (ICon.Gp ((a_addr, b_addr, a_token_id, a_amount) : (address, address, nat, nat))) 0 Token0.addr ICon.Contract.Transfer in
+      let op1 = Xfer (ICon.Gp ((b_addr, a_addr, b_token_id, b_amount) : (address, address, nat, nat))) 0 Token1.addr ICon.Contract.Transfer in
       ops = Cons op0 (Cons op1 Nil)
 
   end
@@ -112,15 +108,15 @@ scope Token0
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     balances_invariant c c' /\
     c.token1_storage = c'.token1_storage /\
-    match gp with
-    | Gp'Token0'transfer from_ to_ token_id amount ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Transfer, ICon.Gp ((from_, to_, token_id, amount) : (address, address, nat, nat)) ->
         ( from_ = sender st \/ c.token0_storage.Token0.operators[token_id][from_][sender st]) /\
           let balances = c.token0_storage.Token0.balances in
           let balances' = c'.token0_storage.Token0.balances in
           let b, b' = update_balance from_ to_ token_id amount balances balances' in
           b = b' /\
           c.token0_storage.Token0.operators = c'.token0_storage.Token0.operators
-    | Gp'Token0'update_operators _ ->
+    | ICon.Contract.Update_operators, _ ->
         c.token0_storage.Token0.balances = c'.token0_storage.Token0.balances
     | _ -> false
     end
@@ -131,13 +127,11 @@ scope Token0
 
     predicate transfer
       (st : step)
-      (from_ : address)
-      (to_ : address)
-      (token_id : nat)
-      (amount : nat)
+      (p : (address, address, nat, nat))
       (s : storage)
       (ops : list operation)
       (s' : storage) =
+        let (from_, to_, token_id, amount) = p in
         let sender = sender st in
         (from_ = sender \/ s.operators[token_id][from_][sender]) /\
         s.balances[token_id][from_] >= amount /\
@@ -179,15 +173,15 @@ scope Token1
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     balances_invariant c c' /\
     c.token0_storage = c'.token0_storage /\
-    match gp with
-    | Gp'Token1'transfer from_ to_ token_id amount ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Transfer, ICon.Gp ((from_, to_, token_id, amount) : (address, address, nat, nat)) ->
         ( from_ = sender st \/ c.token1_storage.Token1.operators[token_id][from_][sender st]) /\
           let balances = c.token1_storage.Token1.balances in
           let balances' = c'.token1_storage.Token1.balances in
           let b, b' = update_balance from_ to_ token_id amount balances balances' in
           b = b' /\
           c.token1_storage.Token1.operators = c'.token1_storage.Token1.operators
-    | Gp'Token1'update_operators _ ->
+    | ICon.Contract.Update_operators, _ ->
         c.token1_storage.Token1.balances = c'.token1_storage.Token1.balances
     | _ -> false
     end
@@ -198,13 +192,11 @@ scope Token1
 
     predicate transfer
       (st : step)
-      (from_ : address)
-      (to_ : address)
-      (token_id : nat)
-      (amount : nat)
+      (p : (address, address, nat, nat))
       (s : storage)
       (ops : list operation)
       (s' : storage) =
+        let (from_, to_, token_id, amount) = p in
         let sender = sender st in
         (from_ = sender \/ s.operators[token_id][from_][sender]) /\
         s.balances[token_id][from_] >= amount /\
@@ -241,8 +233,8 @@ scope Implicit0
 
   predicate post (st : step) (gp : gparam) (c : ctx) (c' : ctx) =
     balances_invariant c c' /\
-    match gp with
-    | Gp'Implicit0'default a_token_id a_amount b_addr b_token_id b_amount ->
+    match st.entrypoint, gp with
+    | ICon.Contract.Default, ICon.Gp ((a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) : (address, nat, nat, address, nat, nat)) ->
         let a_addr = self st in
         c.token1_storage.Token1.operators[b_token_id][b_addr][Swap.addr] /\
         ( let balances = c.token0_storage.Token0.balances in
@@ -264,17 +256,14 @@ scope Implicit0
     (* Swap tokens with [b_addr] if [b_addr] set [Swap.addr] as an operator of [b_token_id] token in [Token1] *)
     predicate default
       (st : step)
-      (a_token_id : nat)
-      (a_amount : nat)
-      (b_addr : address)
-      (b_token_id : nat)
-      (b_amount : nat)
+      (p : (address, nat, nat, address, nat, nat))
       (s : storage)
       (ops : list operation)
       (s' : storage) =
-      let op0 = Xfer (Gp'Token0'update_operators (Left (self st, (Swap.addr, a_token_id)))) 0 Token0.addr in
-      let op1 = Xfer (Gp'Swap'swap (self st) a_token_id a_amount b_addr b_token_id b_amount) 0 Swap.addr in
-      let op2 = Xfer (Gp'Token0'update_operators (Right (self st, (Swap.addr, a_token_id)))) 0 Token0.addr in
+      let (a_addr, a_token_id, a_amount, b_addr, b_token_id, b_amount) = p in
+      let op0 = Xfer (ICon.Gp ((Left (self st, (Swap.addr, a_token_id))) : (or (address, (address, nat)) (address, (address, nat))))) 0 Token0.addr ICon.Contract.Update_operators in
+      let op1 = Xfer (ICon.Gp (((self st), a_token_id, a_amount, b_addr, b_token_id, b_amount) : (address, nat, nat, address, nat, nat))) 0 Swap.addr ICon.Contract.Swap in
+      let op2 = Xfer (ICon.Gp ((Right (self st, (Swap.addr, a_token_id))) : (or (address, (address, nat)) (address, (address, nat))))) 0 Token0.addr ICon.Contract.Update_operators in
       ops = Cons op0 (Cons op1 (Cons op2 Nil))
   end
 end

--- a/lib/mlw/preambles.mlw
+++ b/lib/mlw/preambles.mlw
@@ -31,6 +31,17 @@ predicate is__tuple5_wf
   let (a,b,c,d,e) = abcde in
   is_a_wf a /\ is_b_wf b /\ is_c_wf c /\ is_d_wf d /\ is_e_wf e
 
+predicate is__tuple6_wf
+  (is_a_wf : 'a -> bool)
+  (is_b_wf : 'b -> bool)
+  (is_c_wf : 'c -> bool)
+  (is_d_wf : 'd -> bool)
+  (is_e_wf : 'e -> bool)
+  (is_f_wf : 'f -> bool)
+  (abcdef : ('a, 'b, 'c, 'd, 'e, 'f)) =
+  let (a,b,c,d,e,f) = abcdef in
+  is_a_wf a /\ is_b_wf b /\ is_c_wf c /\ is_d_wf d /\ is_e_wf e /\ is_f_wf f
+
 predicate is_list_wf (_ : 'a -> bool) (_ : list 'a) = true
 
 predicate is_unit_wf (_ : unit) = true


### PR DESCRIPTION
Update mixer, mixer_with_implicit, token_swap and token_swap_with_implicit to follow the change of `gparam`

